### PR TITLE
test: add remote file test

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,11 +5,22 @@ describe('ipx', () => {
   let ipx: IPX
   it('createIPX', () => {
     ipx = createIPX({
-      dir: resolve(__dirname, 'assets')
+      dir: resolve(__dirname, 'assets'),
+      domains: ['raw.githubusercontent.com'],
+      alias: {
+        'gh-raw': 'https://raw.githubusercontent.com'
+      }
     })
   })
 
-  it('data', async () => {
+  it('remote file', async () => {
+    const src = await ipx('gh-raw/unjs/ipx/main/test/assets/bliss.jpg')
+    const { data, format } = await src.data()
+    expect(data).toBeInstanceOf(Buffer)
+    expect(format).toBe('jpeg')
+  })
+
+  it('local file', async () => {
     const src = await ipx('bliss.jpg')
     const { data, format } = await src.data()
     expect(data).toBeInstanceOf(Buffer)


### PR DESCRIPTION
Hello :)

have an addition here for the test, there is still missing the retrieval of an external resource.

The whole thing has now but a background ;) we use in our package `nuxt-speedkit` the `@nuxt/image` and can not update here for a long time https://github.com/GrabarzUndPartner/nuxt-speedkit/pull/521.

This all came with the `ipx` update to `ohmyfetch` with the included `node-fetch@3`.

**Could find two problems:**

1. `node-fetch` update to version 3 brings errors when calling many requests. 

![Ohne Titel 13](https://user-images.githubusercontent.com/8287751/159757001-b7c10acd-4591-4874-8e4d-0b741d1deb1e.png)

 This topic can be found here: 
    - [node-fetch/node-fetch#1474](https://github.com/node-fetch/node-fetch/pull/1474)
    - [node-fetch/node-fetch#1325](https://github.com/node-fetch/node-fetch/pull/1325)

And can be easily reproduced with the many call to http://localhost:3000/width_200/https://avatars.githubusercontent.com/u/23360933?s=500 in dev mode.

2. Another problem I encountered is in the test.
There I get this error message when running `ohmyfetch.fetch` and in worst case a `segment fault` `jest`.

|Error Message|Segment Fault|
|--|--|
|![image](https://user-images.githubusercontent.com/8287751/159757651-507bda2c-a5ea-4390-84b7-7cdf3ff7ff23.png)|![image](https://user-images.githubusercontent.com/8287751/159757807-7ad979ca-fa07-4e67-8312-5b9712bbdbf4.png)|

I created a [small repo](https://github.com/ThornWalli/jest-ohmyfetch-test) for `ohmyfetch`, in the test you can see that the call has a problem. 

Therefore, this test will probably not be passed in PR.

Could I run it completely if I replaced `ohmyfetch` with `node-fetch`or changed the import to:
```
import { fetch } from 'ohmyfetch/dist/node.mjs'
```

In both cases, I had to extend the `jest` configuration with `babel`, because `node-fetch@3` runs in `jest` only as ESM (https://github.com/node-fetch/node-fetch/issues/1289) and the node.mjs has to be converted as well.

Now I'm asking myself, what's the next step here?

1. wait for a `node-fetch@3` update, where one of the given PRs is included.
2. the use of `ohmyfetch` in the `jest` must work. (rollup issue?)

The easiest solution would be to switch back from `ohmyfetch` to `node-fetch@2`.


Thanks already for the help :)

https://github.com/unjs/ohmyfetch/issues/57