### PR TITLE
feat(options): add fetch option property for resource request

### DIFF
--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -31,7 +31,7 @@ export interface IPXOptions {
   dir?: false | string
   domains?: false | string[]
   alias: Record<string, string>,
-  fetchOptions: { [key: string]: any },
+  fetchOptions: { [key: string]: any } | Function,
   // TODO: Create types
   // https://github.com/lovell/sharp/blob/master/lib/constructor.js#L130
   sharp?: { [key: string]: any }

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -33,6 +33,7 @@ export interface IPXOptions {
   alias: Record<string, string>,
   // TODO: Create types
   // https://github.com/lovell/sharp/blob/master/lib/constructor.js#L130
+  fetchOptions: { [key: string]: any },
   sharp?: { [key: string]: any }
 }
 
@@ -45,6 +46,7 @@ export function createIPX (userOptions: Partial<IPXOptions>): IPX {
     dir: getEnv('IPX_DIR', '.'),
     domains: getEnv('IPX_DOMAINS', []),
     alias: getEnv('IPX_ALIAS', {}),
+    fetchOptions: getEnv('IPX_FETCH_OPTIONS', {}),
     sharp: {}
   }
   const options: IPXOptions = defu(userOptions, defaults) as IPXOptions
@@ -64,7 +66,8 @@ export function createIPX (userOptions: Partial<IPXOptions>): IPX {
   }
   if (options.domains) {
     ctx.sources.http = createHTTPSource({
-      domains: options.domains
+      domains: options.domains,
+      fetchOptions: options.fetchOptions
     })
   }
 

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -31,9 +31,9 @@ export interface IPXOptions {
   dir?: false | string
   domains?: false | string[]
   alias: Record<string, string>,
+  fetchOptions: { [key: string]: any },
   // TODO: Create types
   // https://github.com/lovell/sharp/blob/master/lib/constructor.js#L130
-  fetchOptions: { [key: string]: any },
   sharp?: { [key: string]: any }
 }
 

--- a/src/sources/http.ts
+++ b/src/sources/http.ts
@@ -31,7 +31,7 @@ export const createHTTPSource: SourceFactory = (options: any) => {
     const response = await fetch(id, {
       // @ts-ignore
       agent: id.startsWith('https') ? httpsAgent : httpAgent,
-      ...options.fetchOptions
+      ...(typeof options.fetchOptions === 'function' ? await options.fetchOptions() : options.fetchOptions)
     })
 
     if (!response.ok) {

--- a/src/sources/http.ts
+++ b/src/sources/http.ts
@@ -30,7 +30,8 @@ export const createHTTPSource: SourceFactory = (options: any) => {
 
     const response = await fetch(id, {
       // @ts-ignore
-      agent: id.startsWith('https') ? httpsAgent : httpAgent
+      agent: id.startsWith('https') ? httpsAgent : httpAgent,
+      ...options.fetchOptions
     })
 
     if (!response.ok) {


### PR DESCRIPTION
I have the case that the resources are behind an OAuth and need to send an `Authorization` header with the fetch.

I added a new property `fetchOptions` to the options. This will be passed through to the fetch.

**Usage example:**
```js
const ipx = createIPX({
  domains: […],
  aliases: {…},

  fetchOptions: {
    headers: {
      Authorization: 'Bearer …'
    }
  },

  // or function call for token handling

  fetchOptions: async () => {
    headers: {
      Authorization: await getToken()
    }
  }
});
```