### PR TITLE
feat: support experimental `auto` format

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,54 +50,55 @@ Resize to `200x200px` using `embed` method and change format to `webp`:
 
 `http://localhost:3000/embed,f_webp,s_200x200/static/buffalo.png`
 
-When `IPX_FORMAT_AUTO_ENABLED` is `true`, Change format to it that selected based on [`Accept`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept) header:
-
-`http://localhost:3000/f_auto/static/buffalo.png`
-
 ### Modifiers
 
-| Property        | Docs                                                            | Example                                                     | Comments                                                                                                                                                          |
-| --------------- | :-------------------------------------------------------------- | :---------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| width / w       | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `http://localhost:3000/width_200/buffalo.png`               |
-| height / h      | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `http://localhost:3000/height_200/buffalo.png`              |
-| resize / s      | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `http://localhost:3000/s_200x200/buffalo.png`               |
-| fit             | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `http://localhost:3000/s_200x200,fit_outside/buffalo.png`   | Sets `fit` option for `resize`.
-| position / pos  | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `http://localhost:3000/s_200x200,pos_top/buffalo.png`       | Sets `position` option for `resize`.
-| trim            | [Docs](https://sharp.pixelplumbing.com/api-resize#trim)         | `http://localhost:3000/trim_100/buffalo.png`                |
-| format / f      | [Docs](https://sharp.pixelplumbing.com/api-output#toformat)     | `http://localhost:3000/format_webp/buffalo.png`             | Supported format: `jpg`, `jpeg`, `png`, `webp`, `avif`, `gif`, `heif`, `tiff`. Experimental support `auto` with the Connect/Express middleware. |
-| quality / q     | \_                                                              | `http://localhost:3000/quality_50/buffalo.png`              | Accepted values: 0 to 100                                                                                                                                         |
-| rotate          | [Docs](https://sharp.pixelplumbing.com/api-operation#rotate)    | `http://localhost:3000/rotate_45/buffalo.png`               |
-| enlarge         | \_                                                              | `http://localhost:3000/enlarge,s_2000x2000/buffalo.png`     | Allow the image to be upscaled. By default the returned image will never be larger than the source in any dimension, while preserving the requested aspect ratio. |
-| flip            | [Docs](https://sharp.pixelplumbing.com/api-operation#flip)      | `http://localhost:3000/flip/buffalo.png`                    |
-| flop            | [Docs](https://sharp.pixelplumbing.com/api-operation#flop)      | `http://localhost:3000/flop/buffalo.png`                    |
-| sharpen         | [Docs](https://sharp.pixelplumbing.com/api-operation#sharpen)   | `http://localhost:3000/sharpen_30/buffalo.png`              |
-| median          | [Docs](https://sharp.pixelplumbing.com/api-operation#median)    | `http://localhost:3000/median_10/buffalo.png`               |
-| blur            | [Docs](https://sharp.pixelplumbing.com/api-operation#blur)      | `http://localhost:3000/blur_5/buffalo.png`                  |
-| gamma           | [Docs](https://sharp.pixelplumbing.com/api-operation#gamma)     | `http://localhost:3000/gamma_3/buffalo.png`                 |
-| negate          | [Docs](https://sharp.pixelplumbing.com/api-operation#negate)    | `http://localhost:3000/negate/buffalo.png`                  |
-| normalize       | [Docs](https://sharp.pixelplumbing.com/api-operation#normalize) | `http://localhost:3000/normalize/buffalo.png`               |
-| threshold       | [Docs](https://sharp.pixelplumbing.com/api-operation#threshold) | `http://localhost:3000/threshold_10/buffalo.png`            |
-| tint            | [Docs](https://sharp.pixelplumbing.com/api-colour#tint)         | `http://localhost:3000/tint_1098123/buffalo.png`            |
-| grayscale       | [Docs](https://sharp.pixelplumbing.com/api-colour#grayscale)    | `http://localhost:3000/grayscale/buffalo.png`               |
-| animated        | -                                                               | `http://localhost:3000/animated/buffalo.gif`                | Experimental                                                                                                                                                      |
+| Property       | Docs                                                            | Example                                                   | Comments                                                                                                                                                          |
+| -------------- | :-------------------------------------------------------------- | :-------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| width / w      | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `http://localhost:3000/width_200/buffalo.png`             |
+| height / h     | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `http://localhost:3000/height_200/buffalo.png`            |
+| resize / s     | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `http://localhost:3000/s_200x200/buffalo.png`             |
+| fit            | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `http://localhost:3000/s_200x200,fit_outside/buffalo.png` | Sets `fit` option for `resize`.                                                                                                                                   |
+| position / pos | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `http://localhost:3000/s_200x200,pos_top/buffalo.png`     | Sets `position` option for `resize`.                                                                                                                              |
+| trim           | [Docs](https://sharp.pixelplumbing.com/api-resize#trim)         | `http://localhost:3000/trim_100/buffalo.png`              |
+| format / f     | [Docs](https://sharp.pixelplumbing.com/api-output#toformat)     | `http://localhost:3000/format_webp/buffalo.png`           | Supported format: `jpg`, `jpeg`, `png`, `webp`, `avif`, `gif`, `heif`, `tiff` and `auto` (experimental only with middleware)                                      |
+| quality / q    | \_                                                              | `http://localhost:3000/quality_50/buffalo.png`            | Accepted values: 0 to 100                                                                                                                                         |
+| rotate         | [Docs](https://sharp.pixelplumbing.com/api-operation#rotate)    | `http://localhost:3000/rotate_45/buffalo.png`             |
+| enlarge        | \_                                                              | `http://localhost:3000/enlarge,s_2000x2000/buffalo.png`   | Allow the image to be upscaled. By default the returned image will never be larger than the source in any dimension, while preserving the requested aspect ratio. |
+| flip           | [Docs](https://sharp.pixelplumbing.com/api-operation#flip)      | `http://localhost:3000/flip/buffalo.png`                  |
+| flop           | [Docs](https://sharp.pixelplumbing.com/api-operation#flop)      | `http://localhost:3000/flop/buffalo.png`                  |
+| sharpen        | [Docs](https://sharp.pixelplumbing.com/api-operation#sharpen)   | `http://localhost:3000/sharpen_30/buffalo.png`            |
+| median         | [Docs](https://sharp.pixelplumbing.com/api-operation#median)    | `http://localhost:3000/median_10/buffalo.png`             |
+| blur           | [Docs](https://sharp.pixelplumbing.com/api-operation#blur)      | `http://localhost:3000/blur_5/buffalo.png`                |
+| gamma          | [Docs](https://sharp.pixelplumbing.com/api-operation#gamma)     | `http://localhost:3000/gamma_3/buffalo.png`               |
+| negate         | [Docs](https://sharp.pixelplumbing.com/api-operation#negate)    | `http://localhost:3000/negate/buffalo.png`                |
+| normalize      | [Docs](https://sharp.pixelplumbing.com/api-operation#normalize) | `http://localhost:3000/normalize/buffalo.png`             |
+| threshold      | [Docs](https://sharp.pixelplumbing.com/api-operation#threshold) | `http://localhost:3000/threshold_10/buffalo.png`          |
+| tint           | [Docs](https://sharp.pixelplumbing.com/api-colour#tint)         | `http://localhost:3000/tint_1098123/buffalo.png`          |
+| grayscale      | [Docs](https://sharp.pixelplumbing.com/api-colour#grayscale)    | `http://localhost:3000/grayscale/buffalo.png`             |
+| animated       | -                                                               | `http://localhost:3000/animated/buffalo.gif`              | Experimental                                                                                                                                                      |
 
 ### Config
 
 Config can be customized using `IPX_*` environment variables.
 
 - `IPX_DIR`
+
   - Default: `.` (current working directory)
 
 - `IPX_DOMAINS`
+
   - Default: `[]`
 
 - `IPX_MAX_AGE`
+
   - Default: `300`
 
 - `IPX_ALIAS`
+
   - Default: `{}`
 
 - `IPX_FETCH_OPTIONS`
+
   - Default: `{}`
 
 - `IPX_FORMAT_AUTO_ENABLED`

--- a/README.md
+++ b/README.md
@@ -101,9 +101,6 @@ Config can be customized using `IPX_*` environment variables.
 
   - Default: `{}`
 
-- `IPX_FORMAT_AUTO_ENABLED`
-  - Default: `false`
-
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Resize to `200x200px` using `embed` method and change format to `webp`:
 
 `http://localhost:3000/embed,f_webp,s_200x200/static/buffalo.png`
 
+When `IPX_FORMAT_AUTO_ENABLED` is `true`, Change format to it that selected based on [`Accept`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept) header:
+
+`http://localhost:3000/f_auto/static/buffalo.png`
+
 ### Modifiers
 
 | Property        | Docs                                                            | Example                                                     | Comments                                                                                                                                                          |
@@ -60,7 +64,7 @@ Resize to `200x200px` using `embed` method and change format to `webp`:
 | fit             | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `http://localhost:3000/s_200x200,fit_outside/buffalo.png`   | Sets `fit` option for `resize`.
 | position / pos  | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `http://localhost:3000/s_200x200,pos_top/buffalo.png`       | Sets `position` option for `resize`.
 | trim            | [Docs](https://sharp.pixelplumbing.com/api-resize#trim)         | `http://localhost:3000/trim_100/buffalo.png`                |
-| format          | [Docs](https://sharp.pixelplumbing.com/api-output#toformat)     | `http://localhost:3000/format_webp/buffalo.png`             | Supported format: `jpg`, `jpeg`, `png`, `webp`, `avif`, `gif`, `heif`                                                                                             |
+| format / f      | [Docs](https://sharp.pixelplumbing.com/api-output#toformat)     | `http://localhost:3000/format_webp/buffalo.png`             | Supported format: `jpg`, `jpeg`, `png`, `webp`, `avif`, `gif`, `heif`, `tiff`. Experimental support `auto` with the Connect/Express middleware. |
 | quality / q     | \_                                                              | `http://localhost:3000/quality_50/buffalo.png`              | Accepted values: 0 to 100                                                                                                                                         |
 | rotate          | [Docs](https://sharp.pixelplumbing.com/api-operation#rotate)    | `http://localhost:3000/rotate_45/buffalo.png`               |
 | enlarge         | \_                                                              | `http://localhost:3000/enlarge,s_2000x2000/buffalo.png`     | Allow the image to be upscaled. By default the returned image will never be larger than the source in any dimension, while preserving the requested aspect ratio. |
@@ -81,11 +85,22 @@ Resize to `200x200px` using `embed` method and change format to `webp`:
 Config can be customized using `IPX_*` environment variables.
 
 - `IPX_DIR`
-
   - Default: `.` (current working directory)
 
 - `IPX_DOMAINS`
   - Default: `[]`
+
+- `IPX_MAX_AGE`
+  - Default: `300`
+
+- `IPX_ALIAS`
+  - Default: `{}`
+
+- `IPX_FETCH_OPTIONS`
+  - Default: `{}`
+
+- `IPX_FORMAT_AUTO_ENABLED`
+  - Default: `false`
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "pnpm lint && vitest run --coverage"
   },
   "dependencies": {
+    "@fastify/accept-negotiator": "^1.0.0",
     "consola": "^2.15.3",
     "defu": "^6.1.0",
     "destr": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "pnpm lint && vitest run --coverage"
   },
   "dependencies": {
-    "@fastify/accept-negotiator": "^1.0.0",
+    "@fastify/accept-negotiator": "^1.1.0",
     "consola": "^2.15.3",
     "defu": "^6.1.2",
     "destr": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,7 @@
 lockfileVersion: 5.4
 
 specifiers:
+  '@fastify/accept-negotiator': ^1.0.0
   '@nuxtjs/eslint-config-typescript': ^11.0.0
   '@types/etag': ^1.8.1
   '@types/is-valid-path': ^0.1.0
@@ -29,6 +30,7 @@ specifiers:
   xss: ^1.0.14
 
 dependencies:
+  '@fastify/accept-negotiator': 1.0.0
   consola: 2.15.3
   defu: 6.1.0
   destr: 1.1.1
@@ -304,6 +306,11 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@fastify/accept-negotiator/1.0.0:
+    resolution: {integrity: sha512-4R/N2KfYeld7A5LGkai+iUFMahXcxxYbDp+XS2B1yuL3cdmZLJ9TlCnNzT3q5xFTqsYm0GPpinLUwfSwjcVjyA==}
+    engines: {node: '>=14'}
+    dev: false
 
   /@humanwhocodes/config-array/0.10.4:
     resolution: {integrity: sha512-mXAIHxZT3Vcpg83opl1wGlVZ9xydbfZO3r5YfRSH6Gpp2J/PfdBP0wbDa2sO6/qRbcalpoevVyW6A/fI6LfeMw==}

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -119,7 +119,7 @@ export function createIPX(userOptions: Partial<IPXOptions>): IPX {
       if (mFormat === "jpg") {
         mFormat = "jpeg";
       }
-      let format =
+      const format =
         mFormat && SUPPORTED_FORMATS.has(mFormat)
           ? mFormat
           : SUPPORTED_FORMATS.has(meta.type)

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -115,13 +115,17 @@ export function createIPX(userOptions: Partial<IPXOptions>): IPX {
       const meta = imageMeta(data) as ImageMeta;
 
       // Determine format
-      const mFormat = modifiers.f || modifiers.format;
-      let format = ["jpg", ...SUPPORTED_FORMATS].includes(mFormat)
-        ? mFormat
-        : meta.type;
-      if (format === "jpg") {
-        format = "jpeg";
+      let mFormat = modifiers.f || modifiers.format;
+      if (mFormat === "jpg") {
+        mFormat = "jpeg";
       }
+      let format =
+        mFormat && SUPPORTED_FORMATS.has(mFormat)
+          ? mFormat
+          : SUPPORTED_FORMATS.has(meta.type)
+          ? meta.type
+          : "jpeg";
+
       // Use original svg if format not specified
       if (meta.type === "svg" && !mFormat) {
         return {

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -40,7 +40,7 @@ export interface IPXOptions {
 
 // https://sharp.pixelplumbing.com/#formats
 // (gif and svg are not supported as output)
-const SUPPORTED_FORMATS = ['jpeg', 'png', 'webp', 'avif', 'tiff', 'gif']
+const SUPPORTED_FORMATS = ['jpeg', 'png', 'webp', 'avif', 'tiff', 'heif', 'gif']
 
 export function createIPX (userOptions: Partial<IPXOptions>): IPX {
   const defaults = {
@@ -86,7 +86,7 @@ export function createIPX (userOptions: Partial<IPXOptions>): IPX {
     // Resolve alias
     for (const base in options.alias) {
       if (id.startsWith(base)) {
-        id = joinURL(options.alias[base], id.substr(base.length))
+        id = joinURL(options.alias[base], id.substring(base.length))
       }
     }
 
@@ -107,7 +107,7 @@ export function createIPX (userOptions: Partial<IPXOptions>): IPX {
 
       // Determine format
       const mFormat = modifiers.f || modifiers.format
-      let format = mFormat || meta.type
+      let format = ['jpg', ...SUPPORTED_FORMATS].includes(mFormat) ? mFormat : meta.type
       if (format === 'jpg') {
         format = 'jpeg'
       }

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -122,7 +122,7 @@ export function createIPX(userOptions: Partial<IPXOptions>): IPX {
       const format =
         mFormat && SUPPORTED_FORMATS.has(mFormat)
           ? mFormat
-          : SUPPORTED_FORMATS.has(meta.type)
+          : SUPPORTED_FORMATS.has(meta.type) // eslint-disable-line unicorn/no-nested-ternary
           ? meta.type
           : "jpeg";
 


### PR DESCRIPTION
Hi.
Thanks for the great work!

I want to use automatic format selection like cloudinary and imgix.

cloudinary
https://cloudinary.com/documentation/image_transformations#automatic_format_selection_f_auto
imgix
https://docs.imgix.com/apis/rendering/auto/auto#format