### PR TITLE
fix: use utc format for `Last-Modified` header

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -66,7 +66,7 @@ async function _handleRequest (req: IPXHRequest, ipx: IPX): Promise<IPXHResponse
         return res
       }
     }
-    res.headers['Last-Modified'] = (+src.mtime) + ''
+    res.headers['Last-Modified'] = src.mtime.toUTCString()
   }
   if (typeof src.maxAge === 'number') {
     res.headers['Cache-Control'] = `max-age=${+src.maxAge}, public, s-maxage=${+src.maxAge}`

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,7 +14,7 @@ describe('ipx', () => {
   })
 
   it('remote file', async () => {
-    const listener = await listen((req, res) => { serveHandler(req, res, { public: resolve(__dirname, 'assets') }) }, { port: 3000, hostname: 'localhost' })
+    const listener = await listen((req, res) => { serveHandler(req, res, { public: resolve(__dirname, 'assets') }) }, { port: 0 })
     const src = await ipx(`${listener.url}/bliss.jpg`)
     const { data, format } = await src.data()
     expect(data).toBeInstanceOf(Buffer)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,7 +14,7 @@ describe('ipx', () => {
   })
 
   it('remote file', async () => {
-    const listener = await listen((req, res) => { serveHandler(req, res, { public: resolve(__dirname, 'assets') }) }, { port: 0 })
+    const listener = await listen((req, res) => { serveHandler(req, res, { public: resolve(__dirname, 'assets') }) }, { port: 3000, hostname: 'localhost' })
     const src = await ipx(`${listener.url}/bliss.jpg`)
     const { data, format } = await src.data()
     expect(data).toBeInstanceOf(Buffer)


### PR DESCRIPTION
The `Last-Modified` header value is not unix-time.
https://developer.mozilla.org/docs/Web/HTTP/Headers/Last-Modified