### PR TITLE
feat: support `sigma` parameter for `blur` operation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Resize to `200x200px` using `embed` method and change format to `webp`:
 | flop            | [Docs](https://sharp.pixelplumbing.com/api-operation#flop)      | `http://localhost:3000/flop/buffalo.png`                    |
 | sharpen         | [Docs](https://sharp.pixelplumbing.com/api-operation#sharpen)   | `http://localhost:3000/sharpen_30/buffalo.png`              |
 | median          | [Docs](https://sharp.pixelplumbing.com/api-operation#median)    | `http://localhost:3000/median_10/buffalo.png`               |
+| blur            | [Docs](https://sharp.pixelplumbing.com/api-operation#blur)      | `http://localhost:3000/blur_5/buffalo.png`                  |
 | gamma           | [Docs](https://sharp.pixelplumbing.com/api-operation#gamma)     | `http://localhost:3000/gamma_3/buffalo.png`                 |
 | negate          | [Docs](https://sharp.pixelplumbing.com/api-operation#negate)    | `http://localhost:3000/negate/buffalo.png`                  |
 | normalize       | [Docs](https://sharp.pixelplumbing.com/api-operation#normalize) | `http://localhost:3000/normalize/buffalo.png`               |

--- a/src/handlers/handlers.ts
+++ b/src/handlers/handlers.ts
@@ -186,8 +186,8 @@ export const median: Handler = {
 // https://sharp.pixelplumbing.com/api-operation#blur
 export const blur: Handler = {
   args: [VArgument, VArgument, VArgument],
-  apply: (_context, pipe) => {
-    return pipe.blur();
+  apply: (_context, pipe, sigma) => {
+    return pipe.blur(sigma);
   },
 };
 


### PR DESCRIPTION
This pull request allows using the sigma value for the blur modifier:

![image](https://user-images.githubusercontent.com/16585568/233214971-42c48038-7b16-4a2b-826c-ec6c970da35b.png)
![image](https://user-images.githubusercontent.com/16585568/233215279-1d509c5e-964e-41a3-a9bf-866a12986e4d.png)
![image](https://user-images.githubusercontent.com/16585568/233215003-ebd63a13-c50d-41f0-aca1-6e54f87a4ccb.png)

and it also adds a row to the modifiers table in the README.md.