### PR TITLE
feat: cache support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,11 @@
     "image-meta": "^0.1.1",
     "listhen": "^1.0.4",
     "node-fetch-native": "^1.1.0",
+    "ohash": "^1.1.2",
     "pathe": "^1.1.0",
     "sharp": "^0.32.1",
     "ufo": "^1.1.2",
+    "unstorage": "^1.6.1",
     "xss": "^1.0.14"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   consola:
@@ -22,6 +26,9 @@ dependencies:
   node-fetch-native:
     specifier: ^1.1.0
     version: 1.1.0
+  ohash:
+    specifier: ^1.1.2
+    version: 1.1.2
   pathe:
     specifier: ^1.1.0
     version: 1.1.0
@@ -31,6 +38,9 @@ dependencies:
   ufo:
     specifier: ^1.1.2
     version: 1.1.2
+  unstorage:
+    specifier: ^1.6.1
+    version: 1.6.1
   xss:
     specifier: ^1.0.14
     version: 1.0.14
@@ -545,6 +555,10 @@ packages:
     resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
     dev: true
 
+  /@ioredis/commands@1.2.0:
+    resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
+    dev: false
+
   /@istanbuljs/schema@0.1.3:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
@@ -1013,7 +1027,6 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-    dev: true
 
   /arch@2.2.0:
     resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
@@ -1091,7 +1104,6 @@ packages:
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
-    dev: true
 
   /bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
@@ -1130,7 +1142,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.0.1
-    dev: true
 
   /browserslist@4.21.5:
     resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
@@ -1305,7 +1316,6 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.2
-    dev: true
 
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -1344,6 +1354,11 @@ packages:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
     dev: true
+
+  /cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -1424,6 +1439,10 @@ packages:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
     dev: true
 
+  /cookie-es@1.0.0:
+    resolution: {integrity: sha512-mWYvfOLrfEc996hlKcdABeIiPHUPC6DM2QYZdGGOvhOTbA3tjm2eBwqlJpoFdjC89NI4Qt6h0Pu06Mp+1Pj5OQ==}
+    dev: false
+
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -1465,7 +1484,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1528,6 +1546,11 @@ packages:
 
   /defu@6.1.2:
     resolution: {integrity: sha512-+uO4+qr7msjNNWKYPHqN/3+Dx3NFkmIzayk2L1MyZQlvgZb/J1A0fo410dpKrN2SnqFjt8n4JL8fDJE0wIgjFQ==}
+
+  /denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+    dev: false
 
   /destr@1.2.2:
     resolution: {integrity: sha512-lrbCJwD9saUQrqUfXvl6qoM+QN3W7tLV5pAOs+OqOmopCCz/JkE05MHedJR1xfk4IAnZuJXPVuN5+7jNA2ZCiA==}
@@ -2159,7 +2182,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
 
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -2237,7 +2259,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /function-bind@1.1.1:
@@ -2324,7 +2345,6 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       is-glob: 4.0.3
-    dev: true
 
   /glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -2410,6 +2430,18 @@ packages:
   /grapheme-splitter@1.0.4:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
+
+  /h3@1.6.6:
+    resolution: {integrity: sha512-DWu2s11OuuO9suEkX99dXaJoxd1RgPXiM4iDmLdrhGV63GLoav13f3Kdd5/Rw7xNKzhzn2+F2dleQjG66SnMPQ==}
+    dependencies:
+      cookie-es: 1.0.0
+      defu: 6.1.2
+      destr: 1.2.2
+      iron-webcrypto: 0.7.0
+      radix3: 1.0.1
+      ufo: 1.1.2
+      uncrypto: 0.1.2
+    dev: false
 
   /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
@@ -2550,9 +2582,30 @@ packages:
       side-channel: 1.0.4
     dev: true
 
+  /ioredis@5.3.2:
+    resolution: {integrity: sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==}
+    engines: {node: '>=12.22.0'}
+    dependencies:
+      '@ioredis/commands': 1.2.0
+      cluster-key-slot: 1.1.2
+      debug: 4.3.4
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /ip-regex@5.0.0:
     resolution: {integrity: sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: false
+
+  /iron-webcrypto@0.7.0:
+    resolution: {integrity: sha512-WkX32iTcwd79ZsWRPP5wq1Jq6XXfPwO783ZiUBY8uMw4/AByx5WvBmxvYGnpVt6AOVJ0F41Qo420r8lIneT9Wg==}
     dev: false
 
   /is-array-buffer@3.0.2:
@@ -2582,7 +2635,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
-    dev: true
 
   /is-boolean-object@1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
@@ -2631,7 +2683,6 @@ packages:
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -2643,7 +2694,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
-    dev: true
 
   /is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
@@ -2672,7 +2722,6 @@ packages:
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-    dev: true
 
   /is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
@@ -2882,6 +2931,14 @@ packages:
       p-locate: 5.0.0
     dev: true
 
+  /lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+    dev: false
+
+  /lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+    dev: false
+
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
@@ -2907,6 +2964,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
+
+  /lru-cache@9.1.2:
+    resolution: {integrity: sha512-ERJq3FOzJTxBbFjZ7iDs+NiK4VI9Wz+RdrrAB8dio1oV+YvdPzUEE4QNiT2VD51DkIbCYRUUzCRkssXCHqSnKQ==}
+    engines: {node: 14 || >=16.14}
+    dev: false
 
   /magic-string@0.27.0:
     resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
@@ -3064,11 +3126,9 @@ packages:
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
-    dev: true
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3105,6 +3165,10 @@ packages:
 
   /node-fetch-native@1.1.0:
     resolution: {integrity: sha512-nl5goFCig93JZ9FIV8GHT9xpNqXbxQUzkOmKIMKmncsBH9jhg7qKex8hirpymkBFmNQ114chEEG5lS4wgK2I+Q==}
+
+  /node-fetch-native@1.1.1:
+    resolution: {integrity: sha512-9VvspTSUp2Sxbl+9vbZTlFGq9lHwE8GDVVekxx6YsNd1YH59sb3Ba8v3Y3cD8PkLNcileGGcA21PFjVl0jzDaw==}
+    dev: false
 
   /node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -3151,7 +3215,6 @@ packages:
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -3200,11 +3263,9 @@ packages:
       destr: 1.2.2
       node-fetch-native: 1.1.0
       ufo: 1.1.2
-    dev: true
 
   /ohash@1.1.2:
     resolution: {integrity: sha512-9CIOSq5945rI045GFtcO3uudyOkYVY1nyfFxVQp+9BRgslr8jPNiSSrsFGg/BNTUFOLqx0P5tng6G32brIPw0w==}
-    dev: true
 
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -3357,7 +3418,6 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-    dev: true
 
   /pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
@@ -3449,6 +3509,10 @@ packages:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
     dev: true
 
+  /radix3@1.0.1:
+    resolution: {integrity: sha512-y+AcwZ3HcUIGc9zGsNVf5+BY/LxL+z+4h4J3/pp8jxSmy1STaCocPS3qrj4tA5ehUSzqtqK+0Aygvz/r/8vy4g==}
+    dev: false
+
   /range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
     engines: {node: '>= 0.6'}
@@ -3509,7 +3573,18 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
-    dev: true
+
+  /redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+    dependencies:
+      redis-errors: 1.2.0
+    dev: false
 
   /regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
@@ -3759,6 +3834,10 @@ packages:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: true
 
+  /standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+    dev: false
+
   /std-env@3.3.3:
     resolution: {integrity: sha512-Rz6yejtVyWnVjC1RFvNmYL10kgjC49EOghxWn0RFqlCHGFpQx+Xe7yW3I4ceK1SGrWIGMjD5Kbue8W/udkbMJg==}
     dev: true
@@ -3958,7 +4037,6 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
-    dev: true
 
   /touch@3.1.0:
     resolution: {integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==}
@@ -4087,6 +4165,10 @@ packages:
       - supports-color
     dev: true
 
+  /uncrypto@0.1.2:
+    resolution: {integrity: sha512-kuZwRKV615lEw/Xx3Iz56FKk3nOeOVGaVmw0eg+x4Mne28lCotNFbBhDW7dEBCBKyKbRQiCadEZeNAFPVC5cgw==}
+    dev: false
+
   /undefsafe@2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
     dev: true
@@ -4095,6 +4177,53 @@ packages:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
     dev: true
+
+  /unstorage@1.6.1:
+    resolution: {integrity: sha512-GUJzwbP5IStEGZy9/0peRqef5CY9icqApsSu8vxj13admjISyz1g5eYk2wPRBjmZhQ3DUMQ36q+zwTbe68khew==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.4.1
+      '@azure/cosmos': ^3.17.3
+      '@azure/data-tables': ^13.2.2
+      '@azure/identity': ^3.2.2
+      '@azure/keyvault-secrets': ^4.7.0
+      '@azure/storage-blob': ^12.14.0
+      '@planetscale/database': ^1.7.0
+      '@upstash/redis': ^1.20.6
+      '@vercel/kv': ^0.2.1
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/kv':
+        optional: true
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 3.5.3
+      destr: 1.2.2
+      h3: 1.6.6
+      ioredis: 5.3.2
+      listhen: 1.0.4
+      lru-cache: 9.1.2
+      mri: 1.2.0
+      node-fetch-native: 1.1.1
+      ofetch: 1.0.1
+      ufo: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /untildify@4.0.0:
     resolution: {integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==}

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -6,6 +6,8 @@ import { createFilesystemSource, createHTTPSource } from "./sources";
 import { applyHandler, getHandler } from "./handlers";
 import { cachedPromise, getEnv as getEnvironment, createError } from "./utils";
 
+import { tmpdir } from 'os'
+
 // TODO: Move to image-meta
 export interface ImageMeta {
   width: number;
@@ -37,6 +39,8 @@ export interface IPXOptions {
   domains?: false | string[];
   alias: Record<string, string>;
   fetchOptions: RequestInit;
+  cache?: boolean | string;
+  cacheMetadataStore?: Storage;
   // TODO: Create types
   // https://github.com/lovell/sharp/blob/master/lib/constructor.js#L130
   sharp?: { [key: string]: any };
@@ -60,9 +64,14 @@ export function createIPX(userOptions: Partial<IPXOptions>): IPX {
     alias: getEnvironment("IPX_ALIAS", {}),
     fetchOptions: getEnvironment("IPX_FETCH_OPTIONS", {}),
     maxAge: getEnvironment("IPX_MAX_AGE", 300),
+    cache: getEnvironment("IPX_CACHE", 300),
     sharp: {},
   };
   const options: IPXOptions = defu(userOptions, defaults) as IPXOptions;
+
+  if (options.cache === true) {
+    options.cache = tmpdir()
+  }
 
   // Normalize alias to start with leading slash
   options.alias = Object.fromEntries(
@@ -85,6 +94,8 @@ export function createIPX(userOptions: Partial<IPXOptions>): IPX {
       domains: options.domains,
       fetchOptions: options.fetchOptions,
       maxAge: options.maxAge,
+      cache: options.cache,
+      cacheMetadataStore: options.cacheMetadataStore,
     });
   }
 

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -2,6 +2,7 @@ import { defu } from "defu";
 import { imageMeta } from "image-meta";
 import { hasProtocol, joinURL, withLeadingSlash } from "ufo";
 import type { Storage } from "unstorage";
+import { createStorage } from "unstorage";
 import type { Source, SourceData } from "./types";
 import { createFilesystemSource, createHTTPSource } from "./sources";
 import { applyHandler, getHandler } from "./handlers";
@@ -76,6 +77,10 @@ export function createIPX(userOptions: Partial<IPXOptions>): IPX {
   const context: IPXCTX = {
     sources: {},
   };
+
+  if (options.cache && !options.cacheMetadataStore) {
+    options.cacheMetadataStore = createStorage();
+  }
 
   // Init sources
   if (options.dir) {

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -1,12 +1,11 @@
 import { defu } from "defu";
 import { imageMeta } from "image-meta";
 import { hasProtocol, joinURL, withLeadingSlash } from "ufo";
+import type { Storage } from "unstorage";
 import type { Source, SourceData } from "./types";
 import { createFilesystemSource, createHTTPSource } from "./sources";
 import { applyHandler, getHandler } from "./handlers";
 import { cachedPromise, getEnv as getEnvironment, createError } from "./utils";
-
-import { tmpdir } from 'os'
 
 // TODO: Move to image-meta
 export interface ImageMeta {
@@ -39,7 +38,7 @@ export interface IPXOptions {
   domains?: false | string[];
   alias: Record<string, string>;
   fetchOptions: RequestInit;
-  cache?: boolean | string;
+  cache?: boolean;
   cacheMetadataStore?: Storage;
   // TODO: Create types
   // https://github.com/lovell/sharp/blob/master/lib/constructor.js#L130
@@ -64,14 +63,10 @@ export function createIPX(userOptions: Partial<IPXOptions>): IPX {
     alias: getEnvironment("IPX_ALIAS", {}),
     fetchOptions: getEnvironment("IPX_FETCH_OPTIONS", {}),
     maxAge: getEnvironment("IPX_MAX_AGE", 300),
-    cache: getEnvironment("IPX_CACHE", 300),
+    cache: getEnvironment("IPX_CACHE", false),
     sharp: {},
   };
   const options: IPXOptions = defu(userOptions, defaults) as IPXOptions;
-
-  if (options.cache === true) {
-    options.cache = tmpdir()
-  }
 
   // Normalize alias to start with leading slash
   options.alias = Object.fromEntries(

--- a/src/sources/http.ts
+++ b/src/sources/http.ts
@@ -2,7 +2,6 @@ import http from "node:http";
 import https from "node:https";
 import { fetch } from "node-fetch-native";
 
-import { createStorage } from "unstorage";
 import type { Storage } from "unstorage";
 import { hash } from "ohash";
 import { createError, cachedPromise } from "../utils";
@@ -27,10 +26,6 @@ const HTTP_RE = /^https?:\/\//;
 export const createHTTPSource: SourceFactory<HTTPSourceOptions> = (options) => {
   const httpsAgent = new https.Agent({ keepAlive: true });
   const httpAgent = new http.Agent({ keepAlive: true });
-
-  if (options.cache && !options.cacheMetadataStore) {
-    options.cacheMetadataStore = createStorage();
-  }
 
   let _domains = options.domains || [];
   if (typeof _domains === "string") {

--- a/src/sources/http.ts
+++ b/src/sources/http.ts
@@ -73,7 +73,7 @@ export const createHTTPSource: SourceFactory<HTTPSourceOptions> = (options) => {
 
         if (etag) {
           headers.set("If-None-Match", etag);
-        } else {
+        } else if (mtime) {
           headers.set("If-Modified-Since", mtime.toUTCString());
         }
 

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -1,0 +1,127 @@
+import fs from "node:fs";
+import { listen } from "listhen";
+import { resolve } from "pathe";
+import { describe, it, expect, vi } from "vitest";
+import serveHandler from "serve-handler";
+import { createStorage } from "unstorage";
+import { createIPX } from "../src";
+
+describe("ipx with cache storage", () => {
+  it("remote file", async () => {
+    const listener = await listen(
+      (request, res) => {
+        // eslint-disable-next-line unicorn/prefer-module
+        serveHandler(request, res, { public: resolve(__dirname, "assets") });
+      },
+      { port: 3001 }
+    );
+    const ipx = createIPX({
+      // eslint-disable-next-line unicorn/prefer-module
+      dir: resolve(__dirname, "assets"),
+      domains: ["localhost:3001"],
+      cache: true,
+    });
+
+    const source = ipx(`${listener.url}/bliss.jpg`);
+    const { data, format } = await source.data();
+    expect(data).toBeInstanceOf(Buffer);
+    expect(format).toBe("jpeg");
+    await listener.close();
+  });
+
+  it("should save the file with the same key without duplication", async () => {
+    const storage = createStorage();
+
+    const ipx = createIPX({
+      // eslint-disable-next-line unicorn/prefer-module
+      dir: resolve(__dirname, "assets"),
+      domains: ["localhost:3002"],
+      cache: true,
+      cacheMetadataStore: storage,
+    });
+
+    const listener = await listen(
+      (request, res) => {
+        // eslint-disable-next-line unicorn/prefer-module
+        serveHandler(request, res, { public: resolve(__dirname, "assets") });
+      },
+      { port: 3002 }
+    );
+
+    const source = ipx(`${listener.url}bliss.jpg`);
+    await source.data();
+
+    const cached = ipx(`${listener.url}bliss.jpg`);
+    await cached.data();
+
+    expect((await storage.getKeys()).length).toBe(1);
+
+    const cached2 = ipx(`${listener.url}bliss.jpg`);
+    await cached2.data();
+    expect((await storage.getKeys()).length).toBe(1);
+
+    await listener.close();
+  });
+
+  it("should respect 304 responses from http servers", async () => {
+    const ipx = createIPX({
+      // eslint-disable-next-line unicorn/prefer-module
+      dir: resolve(__dirname, "assets"),
+      domains: ["localhost:3003"],
+      cache: true,
+    });
+
+    const serveFileReader = vi.spyOn(fs, "createReadStream");
+    const listener = await listen(
+      (request, res) => {
+        // serveHandler doesn't support if-modified-since header
+        if (request.headers["if-modified-since"]) {
+          res.statusCode = 304;
+          res.end();
+        }
+
+        serveHandler(
+          request,
+          res,
+          // eslint-disable-next-line unicorn/prefer-module
+          { public: resolve(__dirname, "assets") },
+          {
+            createReadStream: serveFileReader,
+          }
+        );
+      },
+      { port: 3003 }
+    );
+
+    const source = ipx(`${listener.url}bliss.jpg`);
+    await source.data();
+
+    const cached = ipx(`${listener.url}bliss.jpg`);
+    await cached.data();
+
+    const cached2 = ipx(`${listener.url}bliss.jpg`);
+    await cached2.data();
+
+    // one - for the original request, two - for checking "if-modified-since" header
+    // if it fails - called time be 5
+    expect(serveFileReader).toHaveBeenCalledTimes(3);
+
+    await listener.close();
+  });
+
+  it("should not store local files to cache", async () => {
+    const storage = createStorage();
+    const ipx = createIPX({
+      // eslint-disable-next-line unicorn/prefer-module
+      dir: resolve(__dirname, "assets"),
+      cache: true,
+      cacheMetadataStore: storage,
+    });
+
+    const source = ipx("bliss.jpg");
+    const { data, format } = await source.data();
+    expect(data).toBeInstanceOf(Buffer);
+    expect(format).toBe("jpeg");
+    expect((await storage.getKeys()).length).toBe(0);
+  });
+});


### PR DESCRIPTION
adds support for caching

based on #47 PR but since there no activity will try propose solution
also related to #30

- [x] switched storage to "unstorage" with default driver
- [x] removed fs direct calls
- [x] switched hash lib to "ohash" (just in case same package scope from unjs)
- [x] tests ready for cache option
- [ ] docs updated

example test with: f_webp&q_70&s_1000x1000/https://images.pexels.com/photos/674010/pexels-photo-674010.jpeg
![изображение](https://github.com/unjs/ipx/assets/47179073/3f98373d-6b98-4bf4-beb7-526d5f30f032)


let me know if i something missed
really need this feature released :)

