### PR TITLE
feat: add limits for modifiers and dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Config can be customized using `IPX_*` environment variables.
 
 - `IPX_LIMITS_MODIFIERS`
 
-  - Default: `['width', 'w', 'height', 'h', 'resize', 's']` (Abbreviated modifiers will be treated as distinct variants.)
+  - Default: `['width', ' w', ' height', ' h', ' resize', ' s', ' fit', ' position', ' pos', ' trim', ' extend', ' extract', ' format', ' f', ' quality', ' q', ' rotate', ' enlarge', ' flip', ' flop', ' sharpen', ' median', ' blur', ' gamma', ' negate', ' normalize', ' threshold', ' tint', ' grayscale', ' animated']` (Abbreviated modifiers will be treated as distinct variants.)
 
   - e.g.: `IPX_LIMITS_MODIFIERS=w, enlarge`
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Config can be customized using `IPX_*` environment variables.
 
   - Default: `[]`
 
-  - e.g.: `IPX_DOMAINS=https://avatars.githubusercontent.com, https://nuxtjs.org`
+  - e.g.: `IPX_DOMAINS=https://avatars.githubusercontent.com, https://nuxt.com`
 
 - `IPX_MAX_AGE`
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Resize to `200x200px` using `embed` method and change format to `webp`:
 
 ### Modifiers
 
-* To prevent server abuse, only width, w, height, h, resize, and s modifiers are enabled by default. Other Modifiers should be defined in the configuration (Config).
 
 | Property       | Docs                                                            | Example                                              | Comments                                                                                                                                                          |
 | -------------- | :-------------------------------------------------------------- | :--------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Resize to `200x200px` using `embed` method and change format to `webp`:
 
 ### Modifiers
 
+* To prevent server abuse, only width, w, height, h, resize, and s modifiers are enabled by default. Other Modifiers should be defined in the configuration (Config).
+
 | Property       | Docs                                                            | Example                                              | Comments                                                                                                                                                          |
 | -------------- | :-------------------------------------------------------------- | :--------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | width / w      | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/width_200/buffalo.png`                             |
@@ -88,6 +90,8 @@ Config can be customized using `IPX_*` environment variables.
 
   - Default: `[]`
 
+  - e.g.: `IPX_DOMAINS=https://avatars.githubusercontent.com, https://nuxtjs.org`
+
 - `IPX_MAX_AGE`
 
   - Default: `300`
@@ -99,6 +103,17 @@ Config can be customized using `IPX_*` environment variables.
 - `IPX_FETCH_OPTIONS`
 
   - Default: `{}`
+
+- `IPX_LIMITS_MODIFIERS`
+
+  - Default: `['width', 'w', 'height', 'h', 'resize', 's']` (Abbreviated modifiers will be treated as distinct variants.)
+
+  - e.g.: `IPX_LIMITS_MODIFIERS=w, enlarge`
+
+- `IPX_LIMITS_MAX_DIMENSIONS`
+
+  - Default: `8192` (px, Both width and height will use this value.)
+
 
 ## License
 

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -65,7 +65,7 @@ export function createIPX(userOptions: Partial<IPXOptions>): IPX {
       modifiers: new Set(
         getEnvironment<string>(
           "IPX_LIMITS_MODIFIERS",
-          "width, w, height, h, resize, s"
+          "width, w, height, h, resize, s, fit, position, pos, trim, extend, extract, format, f, quality, q, rotate, enlarge, flip, flop, sharpen, median, blur, gamma, negate, normalize, threshold, tint, grayscale, animated"
         )
           .split(",")
           .map((s) => s.trim())


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue
#45 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Based on the issues mentioned, using encrypted URLs as a deterrent against abuse should be considered. However, inspired by Cloudinary's approach (where the server stops serving images beyond 8000px, which likely meets current screen usage), and taking into account the limitations on images in the ImageKit.io documentation, we have decided to impose restrictions on the usage of modifiers. Additionally, requests for width or height must conform to the maximum limits. This configuration serves as the minimum guarantee to prevent server abuse when URL encryption is not applied.

Furthermore, an example of using IPX_DOMAINS is added because it defaults to an empty array, but the input value is in the form of a comma-separated string, leading to confusion due to the different data types in use.

ImageKit.io doc about limits image : https://docs.imagekit.io/limits-and-troubleshooting/limits

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
