### PR TITLE
fix: add default `300` maxAge for http adapter

### DIFF
--- a/src/storage/http.ts
+++ b/src/storage/http.ts
@@ -19,7 +19,7 @@ export function ipxHttpStorage(_options: HTTPStorageOptions = {}): IPXStorage {
   let _domains =
     _options.domains || getEnv<string | string[]>("IPX_HTTP_DOMAINS") || [];
   const defaultMaxAge =
-    _options.maxAge || getEnv<string | number>("IPX_HTTP_MAX_AGE");
+    _options.maxAge || getEnv<string | number>("IPX_HTTP_MAX_AGE") || 300;
   const fetchOptions =
     _options.fetchOptions || getEnv("IPX_HTTP_FETCH_OPTIONS") || {};
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
The README specified the `IPX_HTTP_MAX_AGE` default to be `300` but its never set (as a default).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
