### PR TITLE
fix(server): set `cache-control` header only after processing image

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -89,15 +89,6 @@ export function createIPXH3Handler(ipx: IPX) {
       "default-src 'none'",
     );
 
-    // Send Cache-Control header
-    if (typeof sourceMeta.maxAge === "number") {
-      sendResponseHeaderIfNotSet(
-        event,
-        "cache-control",
-        `max-age=${+sourceMeta.maxAge}, public, s-maxage=${+sourceMeta.maxAge}`,
-      );
-    }
-
     // Handle modified time if available
     if (sourceMeta.mtime) {
       // Send Last-Modified header
@@ -117,6 +108,15 @@ export function createIPXH3Handler(ipx: IPX) {
 
     // Process image
     const { data, format } = await img.process();
+
+    // Send Cache-Control header
+    if (typeof sourceMeta.maxAge === "number") {
+      sendResponseHeaderIfNotSet(
+        event,
+        "cache-control",
+        `max-age=${+sourceMeta.maxAge}, public, s-maxage=${+sourceMeta.maxAge}`,
+      );
+    }
 
     // Generate and send ETag header
     const etag = getEtag(data);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, the Cache-Control header is set before image processing takes place. This can lead to the caching of a 500 error in Cloudflare if an exception occurs during image processing. The changes in this pull request move the setting of the Cache-Control header after the image processing to prevent the caching of 500 errors in such scenarios.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
