### PR TITLE
feat(server): add base option to h3 handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ const ipx = createIPX({
   httpStorage: ipxHttpStorage({ domains: ["picsum.photos"] }),
 });
 
-const app = createApp().use("/", createIPXH3Handler(ipx));
+const base = '/'
+
+const app = createApp().use(base, createIPXH3Handler(ipx, { base }));
 
 listen(toNodeListener(app));
 ```

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,11 +22,11 @@ import { IPX } from "./ipx";
 const MODIFIER_SEP = /[&,]/g;
 const MODIFIER_VAL_SEP = /[:=_]/;
 
-export function createIPXH3Handler(ipx: IPX) {
+export function createIPXH3Handler(ipx: IPX, options = { base: "/" }) {
   const _handler = async (event: H3Event) => {
     // Parse URL
     const [modifiersString = "", ...idSegments] = event.path
-      .slice(1 /* leading slash */)
+      .replace(options.base, "")
       .split("/");
 
     const id = safeString(decode(idSegments.join("/")));
@@ -47,7 +47,7 @@ export function createIPXH3Handler(ipx: IPX) {
       });
     }
 
-    // Contruct modifiers
+    // Construct modifiers
     const modifiers: Record<string, string> = Object.create(null);
 
     // Read modifiers from first segment


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request introduces a valuable enhancement to the H3 handler by adding the `base` option. Currently, the base path is expected to be `/`, but with this change, users have the flexibility to set a custom base path according to their requirements.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
