### PR TITLE
fix: correctly handle `format_auto,animated`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Change format to `webp` and keep other things same as source:
 
 `/f_webp/static/buffalo.png`
 
+Automatically convert to a preferred format (avif/webp/jpeg). Uses the browsers `accept` header to negotiate:
+
+`/f_auto/static/buffalo.png`
+
 Keep original format (`png`) and set width to `200`:
 
 `/w_200/static/buffalo.png`

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,7 +66,7 @@ export function createIPXH3Handler(ipx: IPX) {
       const acceptHeader = getRequestHeader(event, "accept") || "";
       const autoFormat = autoDetectFormat(
         acceptHeader,
-        !!(modifiers.a || modifiers.animated),
+        ['a', 'animated'].some(key => key in modifiers),
       );
       delete modifiers.f;
       delete modifiers.format;

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,7 +66,7 @@ export function createIPXH3Handler(ipx: IPX) {
       const acceptHeader = getRequestHeader(event, "accept") || "";
       const autoFormat = autoDetectFormat(
         acceptHeader,
-        ['a', 'animated'].some(key => key in modifiers),
+        ["a", "animated"].some((key) => key in modifiers),
       );
       delete modifiers.f;
       delete modifiers.format;

--- a/src/server.ts
+++ b/src/server.ts
@@ -64,11 +64,12 @@ export function createIPXH3Handler(ipx: IPX) {
     const mFormat = modifiers.f || modifiers.format;
     if (mFormat === "auto") {
       const acceptHeader = getRequestHeader(event, "accept") || "";
+      const animated = modifiers.animated ?? modifiers.a;
       const autoFormat = autoDetectFormat(
         acceptHeader,
         // #234 "animated" param adds {animated: ''} to the modifiers
         // TODO: fix modifiers to normalized to boolean
-        "a" in modifiers || "animated" in modifiers,
+        !!animated || animated === "",
       );
       delete modifiers.f;
       delete modifiers.format;

--- a/src/server.ts
+++ b/src/server.ts
@@ -66,7 +66,9 @@ export function createIPXH3Handler(ipx: IPX) {
       const acceptHeader = getRequestHeader(event, "accept") || "";
       const autoFormat = autoDetectFormat(
         acceptHeader,
-        ["a", "animated"].some((key) => key in modifiers),
+        // #234 "animated" param adds {animated: ''} to the modifiers
+        // TODO: fix modifiers to normalized to boolean
+        "a" in modifiers || "animated" in modifiers,
       );
       delete modifiers.f;
       delete modifiers.format;


### PR DESCRIPTION
Fixes #234

Using `animated` modifier creates the following modifier key/value which wasn't seen as a truthy value when used in combination with `format_auto` meaning the format selection wasn't limited to "image/webp", "image/gif":
```
{
  animated: ''
}
```

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
