### PR TITLE
feat: add option to customise URL parsing in IPX server

### DIFF
--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -224,14 +224,12 @@ export function createIPX(userOptions: IPXOptions): IPX {
       const format =
         mFormat && SUPPORTED_FORMATS.has(mFormat)
           ? mFormat
-          : imageMeta.type === "svg" && (mFormat === "svg" || !mFormat)
-            ? "svg"
-            : SUPPORTED_FORMATS.has(imageMeta.type || "") // eslint-disable-line unicorn/no-nested-ternary
-              ? imageMeta.type
-              : "jpeg";
+          : SUPPORTED_FORMATS.has(imageMeta.type || "") // eslint-disable-line unicorn/no-nested-ternary
+            ? imageMeta.type
+            : "jpeg";
 
-      // For SVG format, use the original file or svgo if it is enabled
-      if (format === "svg") {
+      // Use original SVG if format is not specified
+      if (imageMeta.type === "svg" && !mFormat) {
         if (options.svgo === false) {
           return {
             data: sourceData,

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -224,12 +224,14 @@ export function createIPX(userOptions: IPXOptions): IPX {
       const format =
         mFormat && SUPPORTED_FORMATS.has(mFormat)
           ? mFormat
-          : SUPPORTED_FORMATS.has(imageMeta.type || "") // eslint-disable-line unicorn/no-nested-ternary
-            ? imageMeta.type
-            : "jpeg";
+          : imageMeta.type === "svg" && (mFormat === "svg" || !mFormat)
+            ? "svg"
+            : SUPPORTED_FORMATS.has(imageMeta.type || "") // eslint-disable-line unicorn/no-nested-ternary
+              ? imageMeta.type
+              : "jpeg";
 
-      // Use original SVG if format is not specified
-      if (imageMeta.type === "svg" && !mFormat) {
+      // For SVG format, use the original file or svgo if it is enabled
+      if (format === "svg") {
         if (options.svgo === false) {
           return {
             data: sourceData,

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import {
   toPlainHandler,
   toWebHandler,
   createError,
+  EventHandler,
   H3Event,
   H3Error,
   send,
@@ -46,11 +47,14 @@ export type IPXH3HandlerOptions = {
  * Creates an H3 handler to handle images using IPX.
  * @param {IPX} ipx - An IPX instance to handle image requests.
  * @param {IPXH3HandlerOptions} options - Configuration options for the H3 handler instance.
- * @returns {H3Event} An H3 event handler that processes image requests, applies modifiers, handles caching,
+ * @returns {EventHandler} An H3 event handler that processes image requests, applies modifiers, handles caching,
  * and returns the processed image data. See {@link H3Event}.
  * @throws {H3Error} If there are problems with the request parameters or processing the image. See {@link H3Error}.
  */
-export function createIPXH3Handler(ipx: IPX, options?: IPXH3HandlerOptions) {
+export function createIPXH3Handler(
+  ipx: IPX,
+  options?: IPXH3HandlerOptions,
+): EventHandler {
   const { parseUrl } = defu(options, {
     parseUrl: defaultUrlParser,
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,18 +36,11 @@ export function createIPXH3Handler(ipx: IPX) {
     const { modifiers, id } = parseUrlPath(event.path);
 
     // Validate
-    if (Object.keys(modifiers).length === 0) {
-      throw createError({
-        statusCode: 400,
-        statusText: `IPX_MISSING_MODIFIERS`,
-        message: `Modifiers are missing: ${id}`,
-      });
-    }
     if (!id || id === "/") {
       throw createError({
         statusCode: 400,
         statusText: `IPX_MISSING_ID`,
-        message: `Resource id is missing: ${event.path}`,
+        message: `Resource id is missing or malformed: ${event.path}`,
       });
     }
 
@@ -251,7 +244,7 @@ function parseUrlPath(path: string): {
 function parseModifiersString(input: string): Record<string, string> {
   const modifiers: Record<string, string> = Object.create(null);
 
-  if (input === "_" || input === "~") {
+  if (input === "" || input === "_" || input === "~") {
     return modifiers;
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -88,7 +88,7 @@ export function createIPXH3Handler(ipx: IPX, options?: IPXH3HandlerOptions) {
     }
 
     // Create request
-    const img = ipx(id, modifiers);
+    const img = ipx(safeString(id), modifiers);
 
     // Get image meta from source
     const sourceMeta = await img.getSourceMeta();

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { defaultUrlParser, parseModifiersString } from "../src";
+import { H3Event } from "h3";
+
+describe("ipx: defaultUrlParser", () => {
+  it("path with modifiers", async () => {
+    const { id, modifiers } = defaultUrlParser({
+      path: "/w_300&h_300&f_webp/assets/bliss.jpg",
+    } as unknown as H3Event);
+
+    expect(id).toBe("assets/bliss.jpg");
+    expect(modifiers).toEqual({
+      w: "300",
+      h: "300",
+      f: "webp",
+    });
+  });
+
+  it("path with empty modifiers", async () => {
+    const { id, modifiers } = defaultUrlParser({
+      path: "/_/assets2/unjs.jpg",
+    } as unknown as H3Event);
+
+    expect(id).toBe("assets2/unjs.jpg");
+    expect(modifiers).toEqual({});
+  });
+});
+
+describe("ipx: parseModifiersString", () => {
+  it("ordinary modifiers", async () => {
+    const modifiers = parseModifiersString("w_300&h_600&f_webp");
+
+    expect(modifiers).toEqual({
+      w: "300",
+      h: "600",
+      f: "webp",
+    });
+  });
+
+  it("alternative modifier value separators", async () => {
+    const modifiers = parseModifiersString("w:300&h=600&f_jpeg");
+
+    expect(modifiers).toEqual({
+      w: "300",
+      h: "600",
+      f: "jpeg",
+    });
+  });
+
+  it("boolean modifier", async () => {
+    const modifiers = parseModifiersString("animated&s_300x300");
+
+    expect(modifiers).toEqual({
+      animated: "",
+      s: "300x300",
+    });
+  });
+});


### PR DESCRIPTION
This PR enables customisation of IPX image URLs.

When creating an H3 handler, `parseUrl` option can be set to a function which overrides the default URL parsing logic.

When not set, the default logic will be used, which accepts URLs in the form `/<modifiers>/<id>`.

As an example, below is a `parseUrl` function for an alternative URL style in the form `/<id>@@<modifiers>.<format>` — this puts the modifiers in the filename after an `@@` sequence, and the format as the file extension. Such an URL style could be preferable when using IPX to prerender images for static hosting.

```ts
import { createIPXH3App, parseModifiersString } from "ipx";
import { decode } from "ufo";

createIPXH3App(ipx, {
  parseUrl: event => {
    const id = decode(event.path.slice(1 /* remove leading slash */));

    const matches = id.match(/^(.+)@@(.+)\.([^.]+)$/);
    if (matches == null) {
      return {
        id,
        modifiers: {},
      };
    }
    
    const modifiers = parseModifiersString(matches[2]);
    modifiers.format = matches[3];
    delete modifiers.f;

    return {
      id: matches[1],
      modifiers,
    };
  }
});
```

Resolves #54, #160