### PR TITLE
chore: do not bundle `svgo`

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -1,5 +1,4 @@
 import { defineBuildConfig } from "obuild/config";
-import { createRequire } from "node:module";
 import { minifySync } from "oxc-minify";
 
 export default defineBuildConfig({
@@ -8,12 +7,6 @@ export default defineBuildConfig({
       type: "bundle",
       input: ["./src/index.ts", "./src/cli.ts"],
       rolldown: {
-        resolve: {
-          alias: {
-            // ESM (/lib) variant uses createRequire in nested deps which cannot be bundled
-            svgo: createRequire(import.meta.url).resolve("svgo"),
-          },
-        },
         plugins: [
           {
             name: "dist-minify",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "dependencies": {
     "pathe": "^2.0.3",
     "sharp": "^0.34.5",
-    "srvx": "^0.9.7"
+    "srvx": "^0.9.7",
+    "svgo": "^4.0.0"
   },
   "devDependencies": {
     "@fastify/accept-negotiator": "^2.0.1",
@@ -48,7 +49,6 @@
     "obuild": "^0.4.7",
     "oxc-minify": "^0.101.0",
     "prettier": "^3.7.4",
-    "svgo": "^4.0.0",
     "typescript": "^5.9.3",
     "ufo": "^1.6.1",
     "unstorage": "^1.17.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       srvx:
         specifier: ^0.9.7
         version: 0.9.7
+      svgo:
+        specifier: ^4.0.0
+        version: 4.0.0
     devDependencies:
       '@fastify/accept-negotiator':
         specifier: ^2.0.1
@@ -60,9 +63,6 @@ importers:
       prettier:
         specifier: ^3.7.4
         version: 3.7.4
-      svgo:
-        specifier: ^4.0.0
-        version: 4.0.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
`svgo` and its dependencies (`css-tree`, with 810.4KB bundled in v4) are widely used in the ecosystem. Bundling them into `ipx` will only increase the size of the end user's `node_modules`.

- `@nuxt/vite-builder` -> `cssnano` -> `cssnano-preset-default` -> `postcss-svgo` -> `svgo` -> `css-tree`
- `@nuxt/fonts` -> `unifont` / `fontless` -> `css-tree`
- `stylelint` -> `css-tree`