### PR TITLE
fix(modulate): correct args count to match apply parameters

### DIFF
--- a/src/handlers/handlers.ts
+++ b/src/handlers/handlers.ts
@@ -240,7 +240,7 @@ export const threshold: Handler = {
 
 // https://sharp.pixelplumbing.com/api-operation#modulate
 export const modulate: Handler = {
-  args: [VArg],
+  args: [VArg, VArg, VArg],
   apply: (_context, pipe, brightness, saturation, hue) => {
     return pipe.modulate({
       brightness,


### PR DESCRIPTION
## Problem

The `modulate` handler defines 3 parameters (`brightness`, `saturation`, `hue`) in its `apply` function but only parses 1 argument:

```ts
export const modulate: Handler = {
  args: [VArg],  // Only 1 arg parsed
  apply: (_context, pipe, brightness, saturation, hue) => {  // Expects 3
    return pipe.modulate({ brightness, saturation, hue });
  },
};
```

This causes `saturation` and `hue` to always be `undefined`, resulting in errors like:
```
[IPX_ERROR] Expected number above zero for saturation but received undefined
```

## Fix

Change `args: [VArg]` to `args: [VArg, VArg, VArg]` to correctly parse all three arguments from the URL.

```diff
export const modulate: Handler = {
-  args: [VArg],
+  args: [VArg, VArg, VArg],
  apply: (_context, pipe, brightness, saturation, hue) => {
```

After fix, `modulate_2_1_1` correctly parses as `brightness=2, saturation=1, hue=1`.

Fixes #301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* The modulate handler now accepts three separate parameters for brightness, saturation, and hue, providing more granular control over image adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/ipx/pull/303)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->