### PR TITLE
fix: restore string modifier values in `VArg`

### DIFF
--- a/src/handlers/utils.ts
+++ b/src/handlers/utils.ts
@@ -7,6 +7,9 @@ export function VArg(argument: string) {
   if (argument === "Infinity") {
     return Infinity;
   }
+  if (argument === "undefined" || argument === undefined) {
+    return undefined;
+  }
   try {
     const val = JSON.parse(argument);
     const t = typeof val;
@@ -16,6 +19,8 @@ export function VArg(argument: string) {
   } catch {
     // ignore parsing errors
   }
+  // Fallback to the raw string (e.g. "40x40", "cover", "top", hex colors)
+  return argument;
 }
 
 export function parseArgs(


### PR DESCRIPTION
## Summary

`VArg` returned `undefined` for any value that isn't valid JSON, since the `modernize ts usage` refactor swapped `destr` for a bare `JSON.parse`. This silently broke every string-valued modifier:

- `s_40x40` / `s_200x200` (resize) → no resize applied
- `fit_cover`, `pos_top`, `kernel_nearest`
- hex `background` colors

`JSON.parse("40x40")` throws, so `VArg` returned `undefined`, and `resize` then computed `[NaN]` for the dimensions and bailed out.

## Fix

Restore the `destr`-style fallback to the raw string when the value isn't valid JSON, while keeping `"undefined"` mapped to actual `undefined` (relied on by the existing test).

## Test plan

- [x] `pnpm test` (54 passed, 9 skipped)
- [x] Manually verified `/s_40x40/...` now resizes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of edge cases where arguments contain undefined values or non-JSON strings. The system now returns the original argument as a fallback when JSON parsing fails, ensuring more reliable argument processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->