### PR TITLE
fix(handlers): parse all three modulate args (brightness, saturation, hue)

### DIFF
--- a/src/handlers/handlers.ts
+++ b/src/handlers/handlers.ts
@@ -240,7 +240,7 @@ export const threshold: Handler = {
 
 // https://sharp.pixelplumbing.com/api-operation#modulate
 export const modulate: Handler = {
-  args: [VArg],
+  args: [VArg, VArg, VArg],
   apply: (_context, pipe, brightness, saturation, hue) => {
     return pipe.modulate({
       brightness,

--- a/test/handlers/handlers.test.ts
+++ b/test/handlers/handlers.test.ts
@@ -27,6 +27,7 @@ import {
   tint,
   grayscale,
 } from "../../src/handlers/handlers.ts";
+import { applyHandler } from "../../src/handlers/utils.ts";
 
 describe("handlers", () => {
   it("quality.apply() returns expected values", () => {
@@ -323,6 +324,20 @@ describe("handlers", () => {
       brightness: 100,
       saturation: 200,
       hue: 300,
+    });
+  });
+
+  it("modulate parses all three args (brightness, saturation, hue) (#301)", () => {
+    const sharpMock = {
+      modulate: vi.fn(),
+    };
+
+    applyHandler({} as any, sharpMock as any, modulate, "2_1_1");
+
+    expect(sharpMock.modulate).toHaveBeenCalledWith({
+      brightness: 2,
+      saturation: 1,
+      hue: 1,
     });
   });
 


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #301

### 📚 Description

The `modulate` handler declared `args: [VArg]`, so `parseArgs` only pulled the **first** value out of the URL segment. Its `apply` takes three (`brightness, saturation, hue`), so `saturation` and `hue` were always `undefined`.

A request like `/_ipx/modulate_2_1_1/example.png` then failed with:

```
[IPX_ERROR] Expected number above zero for saturation but received undefined of type undefined
```

Fix: declare all three arg mappers — `args: [VArg, VArg, VArg]` — matching the sibling multi-arg handlers, so every value is parsed and forwarded to sharp. One-line change plus a regression test.

Thanks to @wuiyang for pinpointing the exact location (`src/handlers/handlers.ts`).

### ✅ Test

Added a test that drives the handler through `applyHandler` (i.e. through `parseArgs`, not `apply()` directly) so it covers the arg-count contract:

```
modulate parses all three args (brightness, saturation, hue) (#301)
```

- `vitest run test/handlers/handlers.test.ts` → 53 passed (incl. the new test)
- `eslint .` → clean

The existing `modulate.apply() returns expected values` test called `apply()` with three args directly, so it didn't exercise the parsing gap; the new test does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the image modulation command so it now correctly accepts brightness, saturation, and hue values together.
  * Improved handling of modulation inputs so the applied settings match the values provided.

* **Tests**
  * Added coverage for modulation input parsing and verified the expected image adjustment values are passed through.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->