### PR TITLE
fix!: always sanitize svg sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,24 @@ You can universally customize IPX configuration using `IPX_*` environment variab
 | crop           | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/crop_{left}_{top}_{width}_{height}/buffalo.png`    | Alias for extract. Extract/crop a region of the image.                                                                                                            |
 | animated / a   | -                                                               | `/animated/buffalo.gif` or `/a/buffalo.gif`          | Experimental                                                                                                                                                      |
 
+## SVG Security
+
+SVG documents can carry active content, so IPX **always** sanitizes them before serving. Sanitization is independent of optimization: setting `svgo: false` only disables SVGO's optimization plugins.
+
+Removed from every SVG:
+
+- `<script>` elements (including namespaced ones such as `<svg:script>`)
+- Event handler attributes (any `on*` attribute)
+- Embedded foreign documents: `<foreignObject>`, `<iframe>`, `<embed>`, `<object>`, `<base>`, `<link>` and `<meta>`
+- Event handler elements: `<handler>` and `<listener>`
+- SMIL animations (`<animate>`, `<animateMotion>`, `<animateTransform>` and `<set>`) that assign an `on*` attribute or an unsafe URI, which could otherwise re-introduce a handler after load
+- URIs (`href`, `xlink:href` and `src`) with a scheme other than `http:`, `https:`, `mailto:`, `tel:`, `ftp:` or a non-SVG `data:image/*` — in particular `javascript:`, including obfuscated variants using entities or control characters
+- The internal DTD subset (`<!DOCTYPE ... [ ... ]>`) and `<?xml-stylesheet?>` processing instructions
+
+**External references are kept.** Attributes such as `<image href="https://…">`, `<use href="…">`, external fonts and `@import` inside `<style>` are preserved, since stripping them would break legitimate images. They are not a script execution vector, but they do allow the SVG to make requests to third-party origins (and thereby leak the viewer's IP address) when rendered as a document. If this matters for your threat model, host such images from a separate origin or block the requests with a Content-Security-Policy.
+
+The bundled server sends `content-security-policy: default-src 'none'` with every response, which blocks both script execution and external references in browsers that honor it. Custom servers built on the programmatic API should send the same header, since sanitization cannot cover every future browser behavior on its own.
+
 ## License
 
 [MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -189,39 +189,39 @@ You can universally customize IPX configuration using `IPX_*` environment variab
 
 ## Modifiers
 
-| Property       | Docs                                                            | Example                                                          | Comments                                                                                                                                                          |
-| -------------- | :-------------------------------------------------------------- | :--------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| width / w      | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/width_200/buffalo.png` or `/w_200/buffalo.png`                 |
-| height / h     | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/height_200/buffalo.png` or `/h_200/buffalo.png`                |
-| resize / s     | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200/buffalo.png`                                         |
-| kernel         | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200,kernel_nearest/buffalo.png`                          | Supported kernel: `nearest`, `cubic`, `mitchell`, `lanczos2` and `lanczos3` (default).                                                                            |
-| fit            | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200,fit_outside/buffalo.png`                             | Sets `fit` option for `resize`.                                                                                                                                   |
-| position / pos | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200,pos_top/buffalo.png`                                 | Sets `position` option for `resize`.                                                                                                                              |
-| trim           | [Docs](https://sharp.pixelplumbing.com/api-resize#trim)         | `/trim_100/buffalo.png`                                          |
-| extend         | [Docs](https://sharp.pixelplumbing.com/api-resize#extend)       | `/extend_{top}_{right}_{bottom}_{left}_{extendWith}/buffalo.png` | Extend / pad / extrude one or more edges of the image with either the provided background colour or pixels derived from the image.                                |
-| background / b | \_                                                              | `/r_45,b_00ff00/buffalo.png`                                     |
-| extract        | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/extract_{left}_{top}_{width}_{height}/buffalo.png`             | Extract/crop a region of the image.                                                                                                                               |
-| crop           | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/crop_{left}_{top}_{width}_{height}/buffalo.png`                | Alias for extract. Extract/crop a region of the image.                                                                                                            |
-| format / f     | [Docs](https://sharp.pixelplumbing.com/api-output#toformat)     | `/format_webp/buffalo.png` or `/f_webp/buffalo.png`              | Supported format: `jpg`, `jpeg`, `png`, `webp`, `avif`, `gif`, `heif`, `tiff` and `auto` (experimental only with middleware)                                      |
-| quality / q    | \_                                                              | `/quality_50/buffalo.png` or `/q_50/buffalo.png`                 | Accepted values: 0 to 100                                                                                                                                         |
-| rotate         | [Docs](https://sharp.pixelplumbing.com/api-operation#rotate)    | `/rotate_45/buffalo.png`                                         |
-| enlarge        | \_                                                              | `/enlarge,s_2000x2000/buffalo.png`                               | Allow the image to be upscaled. By default the returned image will never be larger than the source in any dimension, while preserving the requested aspect ratio. |
-| flip           | [Docs](https://sharp.pixelplumbing.com/api-operation#flip)      | `/flip/buffalo.png`                                              |
-| flop           | [Docs](https://sharp.pixelplumbing.com/api-operation#flop)      | `/flop/buffalo.png`                                              |
-| sharpen        | [Docs](https://sharp.pixelplumbing.com/api-operation#sharpen)   | `/sharpen_30/buffalo.png`                                        |
-| median         | [Docs](https://sharp.pixelplumbing.com/api-operation#median)    | `/median_10/buffalo.png`                                         |
-| blur           | [Docs](https://sharp.pixelplumbing.com/api-operation#blur)      | `/blur_5/buffalo.png`                                            |
-| unflatten      | [Docs](https://sharp.pixelplumbing.com/api-operation#unflatten) | `/unflatten/buffalo.png`                                         |                                                                                                                                                                   |
-| gamma          | [Docs](https://sharp.pixelplumbing.com/api-operation#gamma)     | `/gamma_3/buffalo.png`                                           |
-| negate         | [Docs](https://sharp.pixelplumbing.com/api-operation#negate)    | `/negate/buffalo.png`                                            |
-| normalize      | [Docs](https://sharp.pixelplumbing.com/api-operation#normalize) | `/normalize/buffalo.png`                                         |
-| threshold      | [Docs](https://sharp.pixelplumbing.com/api-operation#threshold) | `/threshold_10/buffalo.png`                                      |
-| tint           | [Docs](https://sharp.pixelplumbing.com/api-colour#tint)         | `/tint_1098123/buffalo.png`                                      |
-| grayscale      | [Docs](https://sharp.pixelplumbing.com/api-colour#grayscale)    | `/grayscale/buffalo.png`                                         |
-| flatten        | [Docs](https://sharp.pixelplumbing.com/api-operation#flatten)   | `/flatten/buffalo.png`                                           | Remove alpha channel, if any, and replace with background colour.                                                                                                 |
-| modulate       | [Docs](https://sharp.pixelplumbing.com/api-operation#modulate)  | `/modulate_2_1.2_90_10/buffalo.png`                              | Transforms the image using `{brightness}_{saturation}_{hue}_{lightness}`. Trailing arguments may be omitted.                                                      |
-| crop           | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/crop_{left}_{top}_{width}_{height}/buffalo.png`                | Alias for extract. Extract/crop a region of the image.                                                                                                            |
-| animated / a   | -                                                               | `/animated/buffalo.gif` or `/a/buffalo.gif`                      | Experimental                                                                                                                                                      |
+| Property       | Docs                                                            | Example                                              | Comments                                                                                                                                                          |
+| -------------- | :-------------------------------------------------------------- | :--------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| width / w      | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/width_200/buffalo.png` or `/w_200/buffalo.png`     |
+| height / h     | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/height_200/buffalo.png` or `/h_200/buffalo.png`    |
+| resize / s     | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200/buffalo.png`                             |
+| kernel         | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200,kernel_nearest/buffalo.png`              | Supported kernel: `nearest`, `cubic`, `mitchell`, `lanczos2` and `lanczos3` (default).                                                                            |
+| fit            | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200,fit_outside/buffalo.png`                 | Sets `fit` option for `resize`.                                                                                                                                   |
+| position / pos | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200,pos_top/buffalo.png`                     | Sets `position` option for `resize`.                                                                                                                              |
+| trim           | [Docs](https://sharp.pixelplumbing.com/api-resize#trim)         | `/trim_100/buffalo.png`                              |
+| extend         | [Docs](https://sharp.pixelplumbing.com/api-resize#extend)       | `/extend_{top}_{right}_{bottom}_{left}_{extendWith}/buffalo.png`  | Extend / pad / extrude one or more edges of the image with either the provided background colour or pixels derived from the image.                                |
+| background / b | \_                                                              | `/r_45,b_00ff00/buffalo.png`                         |
+| extract        | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/extract_{left}_{top}_{width}_{height}/buffalo.png` | Extract/crop a region of the image.                                                                                                                               |
+| crop           | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/crop_{left}_{top}_{width}_{height}/buffalo.png`    | Alias for extract. Extract/crop a region of the image.                                                                                                            |
+| format / f     | [Docs](https://sharp.pixelplumbing.com/api-output#toformat)     | `/format_webp/buffalo.png` or `/f_webp/buffalo.png`  | Supported format: `jpg`, `jpeg`, `png`, `webp`, `avif`, `gif`, `heif`, `tiff` and `auto` (experimental only with middleware)                                      |
+| quality / q    | \_                                                              | `/quality_50/buffalo.png` or `/q_50/buffalo.png`     | Accepted values: 0 to 100                                                                                                                                         |
+| rotate         | [Docs](https://sharp.pixelplumbing.com/api-operation#rotate)    | `/rotate_45/buffalo.png`                             |
+| enlarge        | \_                                                              | `/enlarge,s_2000x2000/buffalo.png`                   | Allow the image to be upscaled. By default the returned image will never be larger than the source in any dimension, while preserving the requested aspect ratio. |
+| flip           | [Docs](https://sharp.pixelplumbing.com/api-operation#flip)      | `/flip/buffalo.png`                                  |
+| flop           | [Docs](https://sharp.pixelplumbing.com/api-operation#flop)      | `/flop/buffalo.png`                                  |
+| sharpen        | [Docs](https://sharp.pixelplumbing.com/api-operation#sharpen)   | `/sharpen_30/buffalo.png`                            |
+| median         | [Docs](https://sharp.pixelplumbing.com/api-operation#median)    | `/median_10/buffalo.png`                             |
+| blur           | [Docs](https://sharp.pixelplumbing.com/api-operation#blur)      | `/blur_5/buffalo.png`
+| unflatten      | [Docs](https://sharp.pixelplumbing.com/api-operation#unflatten) | `/unflatten/buffalo.png`                             |                                |
+| gamma          | [Docs](https://sharp.pixelplumbing.com/api-operation#gamma)     | `/gamma_3/buffalo.png`                               |
+| negate         | [Docs](https://sharp.pixelplumbing.com/api-operation#negate)    | `/negate/buffalo.png`                                |
+| normalize      | [Docs](https://sharp.pixelplumbing.com/api-operation#normalize) | `/normalize/buffalo.png`                             |
+| threshold      | [Docs](https://sharp.pixelplumbing.com/api-operation#threshold) | `/threshold_10/buffalo.png`                          |
+| tint           | [Docs](https://sharp.pixelplumbing.com/api-colour#tint)         | `/tint_1098123/buffalo.png`                          |
+| grayscale      | [Docs](https://sharp.pixelplumbing.com/api-colour#grayscale)    | `/grayscale/buffalo.png`                             |
+| flatten        | [Docs](https://sharp.pixelplumbing.com/api-operation#flatten)   | `/flatten/buffalo.png`                               | Remove alpha channel, if any, and replace with background colour.                                                                                                 |
+| modulate       | [Docs](https://sharp.pixelplumbing.com/api-operation#modulate)  | `/modulate_2_1.2_90_10/buffalo.png`                  | Transforms the image using `{brightness}_{saturation}_{hue}_{lightness}`. Trailing arguments may be omitted.                                                      |
+| crop           | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/crop_{left}_{top}_{width}_{height}/buffalo.png`    | Alias for extract. Extract/crop a region of the image.                                                                                                            |
+| animated / a   | -                                                               | `/animated/buffalo.gif` or `/a/buffalo.gif`          | Experimental                                                                                                                                                      |
 
 ## SVG Security
 
@@ -235,11 +235,11 @@ Removed from every SVG:
 - Event handler elements: `<handler>` and `<listener>`
 - SMIL animations (`<animate>`, `<animateMotion>`, `<animateTransform>` and `<set>`) that assign an `on*` attribute or an unsafe URI, which could otherwise re-introduce a handler after load
 - URIs (`href`, `xlink:href` and `src`) with a scheme other than `http:`, `https:`, `mailto:`, `tel:`, `ftp:` or a non-SVG `data:image/*` — in particular `javascript:`, including obfuscated variants using entities or control characters
-- The internal DTD subset (`<!DOCTYPE ... [ ... ]>`) and `<?xml-stylesheet?>` processing instructions
+- The `<!DOCTYPE>` declaration and all processing instructions (`<?…?>`), which are serialized unescaped and can smuggle markup past an HTML parser
 
 **External references are kept.** Attributes such as `<image href="https://…">`, `<use href="…">`, external fonts and `@import` inside `<style>` are preserved, since stripping them would break legitimate images. They are not a script execution vector, but they do allow the SVG to make requests to third-party origins (and thereby leak the viewer's IP address) when rendered as a document. If this matters for your threat model, host such images from a separate origin or block the requests with a Content-Security-Policy.
 
-The bundled server sends `content-security-policy: default-src 'none'` with every response, which blocks both script execution and external references in browsers that honor it. Custom servers built on the programmatic API should send the same header, since sanitization cannot cover every future browser behavior on its own.
+The bundled server sends `content-security-policy: default-src 'none'` with successful responses by default, which blocks both script execution and external references in browsers that honor it. Custom servers built on the programmatic API should send the same header, since sanitization cannot cover every future browser behavior on its own.
 
 Sanitization can be disabled with `svg: { unsafeSkipSanitize: true }`. Only do this when every source is fully trusted: IPX will then serve SVG images with XSS payloads unchanged.
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Used by [Nuxt Image](https://image.nuxt.com/) and [Netlify](https://www.npmjs.co
 
 - The server creation APIs have changed. See the Programmatic API section for examples.
 - The JSON error format has changed from `{ error: string }` to `{ status, statusText, message }`.
-- The `svgo` option is now `svg.optimize`. SVG images are always sanitized, even when optimization is disabled. See the SVG Security section.
-- SVG optimization now applies SVGO's `preset-default` unless custom `plugins` are configured (previously only the configured plugins ran).
+- The `svgo` option is now `svg.optimize`. SVG images are always sanitized, even when optimization is disabled.
+- SVG optimization now applies SVGO's `preset-default` unless custom `plugins` are configured (previously only the configured plugins ran), so SVG output is restructured more than before. See the SVG Images section.
 
 ## Using CLI
 
@@ -223,7 +223,53 @@ You can universally customize IPX configuration using `IPX_*` environment variab
 | crop           | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/crop_{left}_{top}_{width}_{height}/buffalo.png`    | Alias for extract. Extract/crop a region of the image.                                                                                                            |
 | animated / a   | -                                                               | `/animated/buffalo.gif` or `/a/buffalo.gif`          | Experimental                                                                                                                                                      |
 
-## SVG Security
+## SVG Images
+
+SVG images are not processed by sharp. They are sanitized, optimized with [svgo](https://github.com/svg/svgo) and served as `image/svg+xml`. Input that is not well-formed XML (an unescaped `&` is a common cause) is rejected with a `400 IPX_INVALID_SVG`.
+
+```ts
+createIPX({
+  storage,
+  svg: {
+    // SVGO config, or `false` to disable optimization
+    optimize: { multipass: true },
+    // Serve SVG images unsanitized. Only for fully trusted sources!
+    unsafeSkipSanitize: false,
+  },
+});
+```
+
+### Optimization
+
+SVGO's `preset-default` is applied unless you configure `plugins` yourself. Output is always a re-serialized document, never byte-identical to the source: ids are renamed, elements that are neither visible nor referenced within the same file are dropped, shapes are converted to paths and `<style>` rules are inlined.
+
+That is fine for images used as `<img src>` or as CSS backgrounds, but it can break consumers that reach into the document:
+
+- Sprite sheets: a `<symbol id="icon">` with no `<use>` in the same file is removed, so `<use href="/sprite.svg#icon">` renders nothing.
+- References by id from outside the file, since ids are renamed (`icon-home` becomes `a`).
+- Selectors in a host page that inlines the SVG, since `<rect>` becomes `<path>` and class-based rules are inlined.
+
+Use `svg: { optimize: false }` to sanitize without optimizing, or keep optimization with the structural plugins disabled (about 1% larger output for typical icons):
+
+```ts
+createIPX({
+  storage,
+  svg: {
+    optimize: {
+      plugins: [
+        {
+          name: "preset-default",
+          params: {
+            overrides: { cleanupIds: false, removeHiddenElems: false },
+          },
+        },
+      ],
+    },
+  },
+});
+```
+
+### Sanitization
 
 SVG documents can carry active content, so IPX **always** sanitizes them before serving. Sanitization is independent of optimization: `svg: { optimize: false }` only disables SVGO's optimization plugins.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Used by [Nuxt Image](https://image.nuxt.com/) and [Netlify](https://www.npmjs.co
 - The server creation APIs have changed. See the Programmatic API section for examples.
 - The JSON error format has changed from `{ error: string }` to `{ status, statusText, message }`.
 - The `svgo` option is now `svg.optimize`. SVG images are always sanitized, even when optimization is disabled. See the SVG Security section.
+- SVG optimization now applies SVGO's `preset-default` unless custom `plugins` are configured (previously only the configured plugins ran).
 
 ## Using CLI
 
@@ -188,39 +189,39 @@ You can universally customize IPX configuration using `IPX_*` environment variab
 
 ## Modifiers
 
-| Property       | Docs                                                            | Example                                              | Comments                                                                                                                                                          |
-| -------------- | :-------------------------------------------------------------- | :--------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| width / w      | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/width_200/buffalo.png` or `/w_200/buffalo.png`     |
-| height / h     | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/height_200/buffalo.png` or `/h_200/buffalo.png`    |
-| resize / s     | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200/buffalo.png`                             |
-| kernel         | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200,kernel_nearest/buffalo.png`              | Supported kernel: `nearest`, `cubic`, `mitchell`, `lanczos2` and `lanczos3` (default).                                                                            |
-| fit            | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200,fit_outside/buffalo.png`                 | Sets `fit` option for `resize`.                                                                                                                                   |
-| position / pos | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200,pos_top/buffalo.png`                     | Sets `position` option for `resize`.                                                                                                                              |
-| trim           | [Docs](https://sharp.pixelplumbing.com/api-resize#trim)         | `/trim_100/buffalo.png`                              |
-| extend         | [Docs](https://sharp.pixelplumbing.com/api-resize#extend)       | `/extend_{top}_{right}_{bottom}_{left}_{extendWith}/buffalo.png`  | Extend / pad / extrude one or more edges of the image with either the provided background colour or pixels derived from the image.                                |
-| background / b | \_                                                              | `/r_45,b_00ff00/buffalo.png`                         |
-| extract        | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/extract_{left}_{top}_{width}_{height}/buffalo.png` | Extract/crop a region of the image.                                                                                                                               |
-| crop           | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/crop_{left}_{top}_{width}_{height}/buffalo.png`    | Alias for extract. Extract/crop a region of the image.                                                                                                            |
-| format / f     | [Docs](https://sharp.pixelplumbing.com/api-output#toformat)     | `/format_webp/buffalo.png` or `/f_webp/buffalo.png`  | Supported format: `jpg`, `jpeg`, `png`, `webp`, `avif`, `gif`, `heif`, `tiff` and `auto` (experimental only with middleware)                                      |
-| quality / q    | \_                                                              | `/quality_50/buffalo.png` or `/q_50/buffalo.png`     | Accepted values: 0 to 100                                                                                                                                         |
-| rotate         | [Docs](https://sharp.pixelplumbing.com/api-operation#rotate)    | `/rotate_45/buffalo.png`                             |
-| enlarge        | \_                                                              | `/enlarge,s_2000x2000/buffalo.png`                   | Allow the image to be upscaled. By default the returned image will never be larger than the source in any dimension, while preserving the requested aspect ratio. |
-| flip           | [Docs](https://sharp.pixelplumbing.com/api-operation#flip)      | `/flip/buffalo.png`                                  |
-| flop           | [Docs](https://sharp.pixelplumbing.com/api-operation#flop)      | `/flop/buffalo.png`                                  |
-| sharpen        | [Docs](https://sharp.pixelplumbing.com/api-operation#sharpen)   | `/sharpen_30/buffalo.png`                            |
-| median         | [Docs](https://sharp.pixelplumbing.com/api-operation#median)    | `/median_10/buffalo.png`                             |
-| blur           | [Docs](https://sharp.pixelplumbing.com/api-operation#blur)      | `/blur_5/buffalo.png`
-| unflatten      | [Docs](https://sharp.pixelplumbing.com/api-operation#unflatten) | `/unflatten/buffalo.png`                             |                                |
-| gamma          | [Docs](https://sharp.pixelplumbing.com/api-operation#gamma)     | `/gamma_3/buffalo.png`                               |
-| negate         | [Docs](https://sharp.pixelplumbing.com/api-operation#negate)    | `/negate/buffalo.png`                                |
-| normalize      | [Docs](https://sharp.pixelplumbing.com/api-operation#normalize) | `/normalize/buffalo.png`                             |
-| threshold      | [Docs](https://sharp.pixelplumbing.com/api-operation#threshold) | `/threshold_10/buffalo.png`                          |
-| tint           | [Docs](https://sharp.pixelplumbing.com/api-colour#tint)         | `/tint_1098123/buffalo.png`                          |
-| grayscale      | [Docs](https://sharp.pixelplumbing.com/api-colour#grayscale)    | `/grayscale/buffalo.png`                             |
-| flatten        | [Docs](https://sharp.pixelplumbing.com/api-operation#flatten)   | `/flatten/buffalo.png`                               | Remove alpha channel, if any, and replace with background colour.                                                                                                 |
-| modulate       | [Docs](https://sharp.pixelplumbing.com/api-operation#modulate)  | `/modulate_2_1.2_90_10/buffalo.png`                  | Transforms the image using `{brightness}_{saturation}_{hue}_{lightness}`. Trailing arguments may be omitted.                                                      |
-| crop           | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/crop_{left}_{top}_{width}_{height}/buffalo.png`    | Alias for extract. Extract/crop a region of the image.                                                                                                            |
-| animated / a   | -                                                               | `/animated/buffalo.gif` or `/a/buffalo.gif`          | Experimental                                                                                                                                                      |
+| Property       | Docs                                                            | Example                                                          | Comments                                                                                                                                                          |
+| -------------- | :-------------------------------------------------------------- | :--------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| width / w      | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/width_200/buffalo.png` or `/w_200/buffalo.png`                 |
+| height / h     | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/height_200/buffalo.png` or `/h_200/buffalo.png`                |
+| resize / s     | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200/buffalo.png`                                         |
+| kernel         | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200,kernel_nearest/buffalo.png`                          | Supported kernel: `nearest`, `cubic`, `mitchell`, `lanczos2` and `lanczos3` (default).                                                                            |
+| fit            | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200,fit_outside/buffalo.png`                             | Sets `fit` option for `resize`.                                                                                                                                   |
+| position / pos | [Docs](https://sharp.pixelplumbing.com/api-resize#resize)       | `/s_200x200,pos_top/buffalo.png`                                 | Sets `position` option for `resize`.                                                                                                                              |
+| trim           | [Docs](https://sharp.pixelplumbing.com/api-resize#trim)         | `/trim_100/buffalo.png`                                          |
+| extend         | [Docs](https://sharp.pixelplumbing.com/api-resize#extend)       | `/extend_{top}_{right}_{bottom}_{left}_{extendWith}/buffalo.png` | Extend / pad / extrude one or more edges of the image with either the provided background colour or pixels derived from the image.                                |
+| background / b | \_                                                              | `/r_45,b_00ff00/buffalo.png`                                     |
+| extract        | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/extract_{left}_{top}_{width}_{height}/buffalo.png`             | Extract/crop a region of the image.                                                                                                                               |
+| crop           | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/crop_{left}_{top}_{width}_{height}/buffalo.png`                | Alias for extract. Extract/crop a region of the image.                                                                                                            |
+| format / f     | [Docs](https://sharp.pixelplumbing.com/api-output#toformat)     | `/format_webp/buffalo.png` or `/f_webp/buffalo.png`              | Supported format: `jpg`, `jpeg`, `png`, `webp`, `avif`, `gif`, `heif`, `tiff` and `auto` (experimental only with middleware)                                      |
+| quality / q    | \_                                                              | `/quality_50/buffalo.png` or `/q_50/buffalo.png`                 | Accepted values: 0 to 100                                                                                                                                         |
+| rotate         | [Docs](https://sharp.pixelplumbing.com/api-operation#rotate)    | `/rotate_45/buffalo.png`                                         |
+| enlarge        | \_                                                              | `/enlarge,s_2000x2000/buffalo.png`                               | Allow the image to be upscaled. By default the returned image will never be larger than the source in any dimension, while preserving the requested aspect ratio. |
+| flip           | [Docs](https://sharp.pixelplumbing.com/api-operation#flip)      | `/flip/buffalo.png`                                              |
+| flop           | [Docs](https://sharp.pixelplumbing.com/api-operation#flop)      | `/flop/buffalo.png`                                              |
+| sharpen        | [Docs](https://sharp.pixelplumbing.com/api-operation#sharpen)   | `/sharpen_30/buffalo.png`                                        |
+| median         | [Docs](https://sharp.pixelplumbing.com/api-operation#median)    | `/median_10/buffalo.png`                                         |
+| blur           | [Docs](https://sharp.pixelplumbing.com/api-operation#blur)      | `/blur_5/buffalo.png`                                            |
+| unflatten      | [Docs](https://sharp.pixelplumbing.com/api-operation#unflatten) | `/unflatten/buffalo.png`                                         |                                                                                                                                                                   |
+| gamma          | [Docs](https://sharp.pixelplumbing.com/api-operation#gamma)     | `/gamma_3/buffalo.png`                                           |
+| negate         | [Docs](https://sharp.pixelplumbing.com/api-operation#negate)    | `/negate/buffalo.png`                                            |
+| normalize      | [Docs](https://sharp.pixelplumbing.com/api-operation#normalize) | `/normalize/buffalo.png`                                         |
+| threshold      | [Docs](https://sharp.pixelplumbing.com/api-operation#threshold) | `/threshold_10/buffalo.png`                                      |
+| tint           | [Docs](https://sharp.pixelplumbing.com/api-colour#tint)         | `/tint_1098123/buffalo.png`                                      |
+| grayscale      | [Docs](https://sharp.pixelplumbing.com/api-colour#grayscale)    | `/grayscale/buffalo.png`                                         |
+| flatten        | [Docs](https://sharp.pixelplumbing.com/api-operation#flatten)   | `/flatten/buffalo.png`                                           | Remove alpha channel, if any, and replace with background colour.                                                                                                 |
+| modulate       | [Docs](https://sharp.pixelplumbing.com/api-operation#modulate)  | `/modulate_2_1.2_90_10/buffalo.png`                              | Transforms the image using `{brightness}_{saturation}_{hue}_{lightness}`. Trailing arguments may be omitted.                                                      |
+| crop           | [Docs](https://sharp.pixelplumbing.com/api-resize#extract)      | `/crop_{left}_{top}_{width}_{height}/buffalo.png`                | Alias for extract. Extract/crop a region of the image.                                                                                                            |
+| animated / a   | -                                                               | `/animated/buffalo.gif` or `/a/buffalo.gif`                      | Experimental                                                                                                                                                      |
 
 ## SVG Security
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Used by [Nuxt Image](https://image.nuxt.com/) and [Netlify](https://www.npmjs.co
 
 - The server creation APIs have changed. See the Programmatic API section for examples.
 - The JSON error format has changed from `{ error: string }` to `{ status, statusText, message }`.
+- The `svgo` option is now `svg.optimize`. SVG images are always sanitized, even when optimization is disabled. See the SVG Security section.
 
 ## Using CLI
 
@@ -223,7 +224,7 @@ You can universally customize IPX configuration using `IPX_*` environment variab
 
 ## SVG Security
 
-SVG documents can carry active content, so IPX **always** sanitizes them before serving. Sanitization is independent of optimization: setting `svgo: false` only disables SVGO's optimization plugins.
+SVG documents can carry active content, so IPX **always** sanitizes them before serving. Sanitization is independent of optimization: `svg: { optimize: false }` only disables SVGO's optimization plugins.
 
 Removed from every SVG:
 
@@ -238,6 +239,8 @@ Removed from every SVG:
 **External references are kept.** Attributes such as `<image href="https://…">`, `<use href="…">`, external fonts and `@import` inside `<style>` are preserved, since stripping them would break legitimate images. They are not a script execution vector, but they do allow the SVG to make requests to third-party origins (and thereby leak the viewer's IP address) when rendered as a document. If this matters for your threat model, host such images from a separate origin or block the requests with a Content-Security-Policy.
 
 The bundled server sends `content-security-policy: default-src 'none'` with every response, which blocks both script execution and external references in browsers that honor it. Custom servers built on the programmatic API should send the same header, since sanitization cannot cover every future browser behavior on its own.
+
+Sanitization can be disabled with `svg: { unsafeSkipSanitize: true }`. Only do this when every source is fully trusted: IPX will then serve SVG images with XSS payloads unchanged.
 
 ## License
 

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -149,13 +149,28 @@ export type IPXOptions = {
   httpStorage?: IPXStorage;
 
   /**
-   * Configuration for the SVGO library used when processing SVG images.
-   *
-   * Set to `false` to disable optimization. SVG sanitization (removal of
-   * scripts, event handlers and unsafe URIs) is always applied.
+   * Options for SVG images, which are served as-is instead of being processed by Sharp.
    * @optional
    */
-  svgo?: false | SVGOConfig;
+  svg?: {
+    /**
+     * Configuration for the SVGO library used to optimize SVG images.
+     *
+     * Set to `false` to disable optimization. Sanitization is applied either way.
+     * @optional
+     */
+    optimize?: false | SVGOConfig;
+
+    /**
+     * Disable SVG sanitization.
+     *
+     * Sanitized SVG images cannot execute scripts. Only disable this if all sources
+     * are fully trusted, as it allows serving SVG images with XSS payloads.
+     * @default false
+     * @optional
+     */
+    unsafeSkipSanitize?: boolean;
+  };
 };
 
 // https://sharp.pixelplumbing.com/#formats
@@ -296,15 +311,25 @@ export function createIPX(userOptions: IPXOptions): IPX {
       // svg is requested or no format is specified. SVG is not a supported
       // output format for sharp, so it cannot be handled by the ternary below.
       if (imageMeta.type === "svg" && (!mFormat || mFormat === "svg")) {
+        const sanitize = !options.svg?.unsafeSkipSanitize;
+        const svgoConfig =
+          options.svg?.optimize === false ? undefined : options.svg?.optimize;
+
+        // Nothing to do if both sanitization and optimization are disabled
+        if (!sanitize && !svgoConfig) {
+          return {
+            data: sourceData,
+            format: "svg+xml",
+            meta: imageMeta,
+          };
+        }
+
         // https://github.com/svg/svgo
         const { optimize } = await getSVGO();
-        // Sanitization is always applied, `svgo: false` only opts out of optimization
-        const svgoConfig = options.svgo === false ? undefined : options.svgo;
         const svg = optimize(sourceData.toString("utf8"), {
           ...svgoConfig,
           plugins: [
-            "removeScripts",
-            sanitizeSVGPlugin,
+            ...(sanitize ? ["removeScripts" as const, sanitizeSVGPlugin] : []),
             ...(svgoConfig?.plugins || []),
           ],
         }).data;

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -152,7 +152,7 @@ export type IPXOptions = {
   httpStorage?: IPXStorage;
 
   /**
-   * Options for SVG images, which are served as-is instead of being processed by Sharp.
+   * Options for SVG images, which are processed by SVGO instead of Sharp.
    * @optional
    */
   svg?: {
@@ -330,11 +330,12 @@ export function createIPX(userOptions: IPXOptions): IPX {
         }
 
         // Sanitization runs first so that optimization only sees safe input.
-        // SVGO applies `preset-default` only when no plugins are configured.
+        // SVGO skips `preset-default` whenever `plugins` is set, which is
+        // always the case here, so it has to be added explicitly.
         const plugins: SVGOPluginConfig[] = sanitize
           ? ["removeScripts", sanitizeSVGPlugin]
           : [];
-        if (svgoConfig?.plugins?.length) {
+        if (svgoConfig?.plugins) {
           plugins.push(...svgoConfig.plugins);
         } else if (shouldOptimize) {
           plugins.push("preset-default");
@@ -342,10 +343,20 @@ export function createIPX(userOptions: IPXOptions): IPX {
 
         // https://github.com/svg/svgo
         const { optimize } = await getSVGO();
-        const svg = optimize(sourceData.toString("utf8"), {
-          ...svgoConfig,
-          plugins,
-        }).data;
+        let svg: string;
+        try {
+          svg = optimize(sourceData.toString("utf8"), {
+            ...svgoConfig,
+            plugins,
+          }).data;
+        } catch (error) {
+          throw new HTTPError({
+            statusCode: 400,
+            statusText: `IPX_INVALID_SVG`,
+            message: `Cannot parse SVG: ${id}`,
+            cause: error,
+          });
+        }
         return {
           data: svg,
           format: "svg+xml",

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -7,7 +7,10 @@ import { cachedPromise, getEnv } from "./utils.ts";
 
 import type { HandlerName } from "./handlers/index.ts";
 import type { SharpOptions } from "sharp";
-import type { Config as SVGOConfig } from "svgo";
+import type {
+  Config as SVGOConfig,
+  PluginConfig as SVGOPluginConfig,
+} from "svgo";
 import type { IPXStorage } from "./types.ts";
 
 type IPXSourceMeta = {
@@ -156,6 +159,7 @@ export type IPXOptions = {
     /**
      * Configuration for the SVGO library used to optimize SVG images.
      *
+     * SVGO's `preset-default` is applied unless custom `plugins` are configured.
      * Set to `false` to disable optimization. Sanitization is applied either way.
      * @optional
      */
@@ -312,11 +316,12 @@ export function createIPX(userOptions: IPXOptions): IPX {
       // output format for sharp, so it cannot be handled by the ternary below.
       if (imageMeta.type === "svg" && (!mFormat || mFormat === "svg")) {
         const sanitize = !options.svg?.unsafeSkipSanitize;
+        const shouldOptimize = options.svg?.optimize !== false;
         const svgoConfig =
           options.svg?.optimize === false ? undefined : options.svg?.optimize;
 
         // Nothing to do if both sanitization and optimization are disabled
-        if (!sanitize && !svgoConfig) {
+        if (!sanitize && !shouldOptimize) {
           return {
             data: sourceData,
             format: "svg+xml",
@@ -324,14 +329,22 @@ export function createIPX(userOptions: IPXOptions): IPX {
           };
         }
 
+        // Sanitization runs first so that optimization only sees safe input.
+        // SVGO applies `preset-default` only when no plugins are configured.
+        const plugins: SVGOPluginConfig[] = sanitize
+          ? ["removeScripts", sanitizeSVGPlugin]
+          : [];
+        if (svgoConfig?.plugins?.length) {
+          plugins.push(...svgoConfig.plugins);
+        } else if (shouldOptimize) {
+          plugins.push("preset-default");
+        }
+
         // https://github.com/svg/svgo
         const { optimize } = await getSVGO();
         const svg = optimize(sourceData.toString("utf8"), {
           ...svgoConfig,
-          plugins: [
-            ...(sanitize ? ["removeScripts" as const, sanitizeSVGPlugin] : []),
-            ...(svgoConfig?.plugins || []),
-          ],
+          plugins,
         }).data;
         return {
           data: svg,

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -2,6 +2,7 @@ import { hasProtocol, joinURL, withLeadingSlash } from "ufo";
 import { HTTPError } from "h3";
 import { imageMeta as getImageMeta, type ImageMeta } from "image-meta";
 import { applyHandler, getHandler } from "./handlers/index.ts";
+import { sanitizeSVGPlugin } from "./svg.ts";
 import { cachedPromise, getEnv } from "./utils.ts";
 
 import type { HandlerName } from "./handlers/index.ts";
@@ -149,6 +150,9 @@ export type IPXOptions = {
 
   /**
    * Configuration for the SVGO library used when processing SVG images.
+   *
+   * Set to `false` to disable optimization. SVG sanitization (removal of
+   * scripts, event handlers and unsafe URIs) is always applied.
    * @optional
    */
   svgo?: false | SVGOConfig;
@@ -288,29 +292,27 @@ export function createIPX(userOptions: IPXOptions): IPX {
       if (mFormat === "jpg") {
         mFormat = "jpeg";
       }
-      // Use original SVG (optimized with svgo if enabled) when svg is
-      // requested or no format is specified. SVG is not a supported output
-      // format for sharp, so it cannot be handled by the ternary below.
+      // Use original SVG (sanitized and optimized with svgo if enabled) when
+      // svg is requested or no format is specified. SVG is not a supported
+      // output format for sharp, so it cannot be handled by the ternary below.
       if (imageMeta.type === "svg" && (!mFormat || mFormat === "svg")) {
-        if (options.svgo === false) {
-          return {
-            data: sourceData,
-            format: "svg+xml",
-            meta: imageMeta,
-          };
-        } else {
-          // https://github.com/svg/svgo
-          const { optimize } = await getSVGO();
-          const svg = optimize(sourceData.toString("utf8"), {
-            ...options.svgo,
-            plugins: ["removeScripts", ...(options.svgo?.plugins || [])],
-          }).data;
-          return {
-            data: svg,
-            format: "svg+xml",
-            meta: imageMeta,
-          };
-        }
+        // https://github.com/svg/svgo
+        const { optimize } = await getSVGO();
+        // Sanitization is always applied, `svgo: false` only opts out of optimization
+        const svgoConfig = options.svgo === false ? undefined : options.svgo;
+        const svg = optimize(sourceData.toString("utf8"), {
+          ...svgoConfig,
+          plugins: [
+            "removeScripts",
+            sanitizeSVGPlugin,
+            ...(svgoConfig?.plugins || []),
+          ],
+        }).data;
+        return {
+          data: svg,
+          format: "svg+xml",
+          meta: imageMeta,
+        };
       }
 
       const format =

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -69,14 +69,22 @@ function isUnsafeURI(value: string): boolean {
 }
 
 function isUnsafeAnimation(attributes: Record<string, string>): boolean {
+  // Attributes are looked up by local name since an HTML parser lowercases
+  // them, turning `ATTRIBUTENAME` into a live `attributeName` when inlined
+  const attrs: Record<string, string> = {};
+  for (const [name, value] of Object.entries(attributes)) {
+    attrs[localName(name)] = value;
+  }
+
   // <set attributeName="onload" to="alert(1)" />
-  if (localName(attributes.attributeName || "").startsWith("on")) {
+  // The value is trimmed, as optimizers do the same before it reaches a browser
+  if (localName(attrs.attributename?.trim() || "").startsWith("on")) {
     return true;
   }
   // <animate attributeName="href" values="javascript:alert(1)" />
   return ANIMATION_VALUE_ATTRS.some((attr) =>
     // `values` is a `;` separated list
-    (attributes[attr] || "").split(";").some((value) => isUnsafeURI(value)),
+    (attrs[attr] || "").split(";").some((value) => isUnsafeURI(value)),
   );
 }
 
@@ -88,9 +96,10 @@ function detach(node: XastChild, parent: XastParent): void {
  * An SVGO plugin that strips the parts of an SVG document that can execute
  * script when the image is served or inlined.
  *
- * It is always applied, regardless of the `svgo` option, and complements
- * SVGO's built-in `removeScripts` plugin which only handles `<script>`, the
- * known `on*` attributes and `javascript:` links on `<a>`.
+ * It is always applied, regardless of the `svg.optimize` option. SVGO's
+ * built-in `removeScripts` plugin runs alongside it as a second layer, but
+ * only handles `<script>`, the known `on*` attributes and `javascript:`
+ * links on `<a>`.
  *
  * External references (`<image href>`, `<use href>`, `@import` in `<style>`,
  * fonts, ...) are intentionally kept. See the security section of the readme.
@@ -98,18 +107,17 @@ function detach(node: XastChild, parent: XastParent): void {
 export const sanitizeSVGPlugin: CustomPlugin = {
   name: "ipx-sanitize",
   fn: () => ({
-    // Drop the internal subset. Entities are already expanded while parsing and
-    // re-emitting the declarations would allow expansion again downstream.
+    // Drop the doctype. Entities of the internal subset are already expanded
+    // while parsing and re-emitting the declarations would allow expansion
+    // again downstream.
     doctype: {
       enter: (node, parentNode) => detach(node, parentNode),
     },
-    // <?xml-stylesheet href="..."?> can load an external (XSLT) stylesheet.
+    // Drop processing instructions. `<?xml-stylesheet href="..."?>` can load an
+    // external (XSLT) stylesheet, and instructions are serialized unescaped, so
+    // `<?foo ><script>...</script>?>` turns into markup in an HTML parser.
     instruction: {
-      enter: (node, parentNode) => {
-        if (node.name.toLowerCase() === "xml-stylesheet") {
-          detach(node, parentNode);
-        }
-      },
+      enter: (node, parentNode) => detach(node, parentNode),
     },
     element: {
       enter: (node, parentNode) => {

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -1,0 +1,145 @@
+import type { CustomPlugin, XastChild, XastParent } from "svgo";
+
+/**
+ * Elements that can execute script or embed non-SVG documents.
+ *
+ * Matched against the local name so namespaced variants (`<svg:script>`) are
+ * covered as well.
+ */
+const UNSAFE_ELEMENTS = new Set([
+  "script",
+  "foreignobject",
+  "iframe",
+  "embed",
+  "object",
+  "handler", // SVG Tiny 1.2 event handler
+  "listener", // SVG Tiny 1.2 event listener
+  "base",
+  "link",
+  "meta",
+]);
+
+/**
+ * SMIL elements that can rewrite attributes of their target *after* load,
+ * which can be used to re-introduce event handlers or `javascript:` URIs.
+ */
+const ANIMATION_ELEMENTS = new Set([
+  "animate",
+  "animatemotion",
+  "animatetransform",
+  "set",
+]);
+
+/** SMIL attributes holding the value(s) assigned to the animated attribute. */
+const ANIMATION_VALUE_ATTRS = ["from", "to", "by", "values"];
+
+/** Attributes (local names) that are resolved as URIs. */
+const URI_ATTRS = new Set(["href", "src"]);
+
+/** URI schemes that cannot execute script. */
+const SAFE_URI_SCHEMES = new Set(["http", "https", "mailto", "tel", "ftp"]);
+
+/**
+ * Non-SVG image data URIs. `image/svg+xml` is excluded since it embeds another
+ * (unsanitized) document.
+ */
+const SAFE_DATA_URI_RE = /^data:image\/(?!svg\+xml)[\w.+-]+[,;]/;
+
+const URI_SCHEME_RE = /^([a-z][\d+.a-z-]*):/;
+
+/** Whitespace and control characters browsers ignore when resolving a URI. */
+// eslint-disable-next-line no-control-regex
+const URI_IGNORED_CHARS_RE = /[\u0000-\u0020]/g;
+
+function localName(name: string): string {
+  const colonIndex = name.indexOf(":");
+  return (colonIndex === -1 ? name : name.slice(colonIndex + 1)).toLowerCase();
+}
+
+function isUnsafeURI(value: string): boolean {
+  const uri = value.replace(URI_IGNORED_CHARS_RE, "").toLowerCase();
+  const scheme = URI_SCHEME_RE.exec(uri)?.[1];
+  if (!scheme) {
+    return false; // Relative URIs and fragment references
+  }
+  if (scheme === "data") {
+    return !SAFE_DATA_URI_RE.test(uri);
+  }
+  return !SAFE_URI_SCHEMES.has(scheme);
+}
+
+function isUnsafeAnimation(attributes: Record<string, string>): boolean {
+  // <set attributeName="onload" to="alert(1)" />
+  if (localName(attributes.attributeName || "").startsWith("on")) {
+    return true;
+  }
+  // <animate attributeName="href" values="javascript:alert(1)" />
+  return ANIMATION_VALUE_ATTRS.some((attr) =>
+    // `values` is a `;` separated list
+    (attributes[attr] || "").split(";").some((value) => isUnsafeURI(value)),
+  );
+}
+
+function detach(node: XastChild, parent: XastParent): void {
+  parent.children = parent.children.filter((child) => child !== node);
+}
+
+/**
+ * An SVGO plugin that strips the parts of an SVG document that can execute
+ * script when the image is served or inlined.
+ *
+ * It is always applied, regardless of the `svgo` option, and complements
+ * SVGO's built-in `removeScripts` plugin which only handles `<script>`, the
+ * known `on*` attributes and `javascript:` links on `<a>`.
+ *
+ * External references (`<image href>`, `<use href>`, `@import` in `<style>`,
+ * fonts, ...) are intentionally kept. See the security section of the readme.
+ */
+export const sanitizeSVGPlugin: CustomPlugin = {
+  name: "ipx-sanitize",
+  fn: () => ({
+    // Drop the internal subset. Entities are already expanded while parsing and
+    // re-emitting the declarations would allow expansion again downstream.
+    doctype: {
+      enter: (node, parentNode) => detach(node, parentNode),
+    },
+    // <?xml-stylesheet href="..."?> can load an external (XSLT) stylesheet.
+    instruction: {
+      enter: (node, parentNode) => {
+        if (node.name.toLowerCase() === "xml-stylesheet") {
+          detach(node, parentNode);
+        }
+      },
+    },
+    element: {
+      enter: (node, parentNode) => {
+        const name = localName(node.name);
+
+        // Unsafe elements are removed along with their subtree
+        if (UNSAFE_ELEMENTS.has(name)) {
+          detach(node, parentNode);
+          return;
+        }
+
+        // SMIL animations that (re)assign event handlers or unsafe URIs
+        if (
+          ANIMATION_ELEMENTS.has(name) &&
+          isUnsafeAnimation(node.attributes)
+        ) {
+          detach(node, parentNode);
+          return;
+        }
+
+        for (const [attr, value] of Object.entries(node.attributes)) {
+          const attrName = localName(attr);
+          if (
+            attrName.startsWith("on") ||
+            (URI_ATTRS.has(attrName) && isUnsafeURI(value))
+          ) {
+            delete node.attributes[attr];
+          }
+        }
+      },
+    },
+  }),
+};

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -85,7 +85,7 @@ describe("ipx", () => {
       expect(format).toBe("jpeg");
     });
 
-    it("removes scripts when svgo is enabled", async () => {
+    it("removes scripts", async () => {
       const { data } = await (await ipx("xss.svg", { f: "svg" })).process();
       expect(data.toString()).not.toContain("<script");
       expect(data.toString()).not.toContain("onclick");

--- a/test/svg.test.ts
+++ b/test/svg.test.ts
@@ -89,8 +89,8 @@ const xssVectors = [
 
 // Sanitization must not depend on optimization being enabled
 describe.each([
-  { name: "svgo enabled", options: undefined },
-  { name: "svgo disabled", options: { svgo: false } as const },
+  { name: "default", options: undefined },
+  { name: "optimize disabled", options: { svg: { optimize: false } } as const },
 ])("sanitize svg ($name)", ({ options }) => {
   it.each(xssVectors)("$name", async ({ svg, absent, present }) => {
     const output = await processSVG(svg, options);
@@ -135,4 +135,10 @@ describe.each([
     expect(output).toContain(`data:image/png;base64,iVBORw0KGgo=`);
     expect(output).toContain(`<animate attributeName="fill"`);
   });
+});
+
+it("svg.unsafeSkipSanitize opts out of sanitization", async () => {
+  const svg = `<svg ${svgAttrs}><script>alert(1)</script></svg>`;
+  const output = await processSVG(svg, { svg: { unsafeSkipSanitize: true } });
+  expect(output).toBe(svg);
 });

--- a/test/svg.test.ts
+++ b/test/svg.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "pathe";
+
+import {
+  type IPXOptions,
+  createIPX,
+  ipxFSStorage,
+  type IPXStorage,
+} from "../src/index.ts";
+
+function inlineStorage(svg: string): IPXStorage {
+  return {
+    name: "inline",
+    getMeta: () => ({}),
+    getData: () => Buffer.from(svg),
+  };
+}
+
+async function processSVG(
+  svg: string,
+  options?: Partial<Omit<IPXOptions, "storage">>,
+): Promise<string> {
+  const ipx = createIPX({ storage: inlineStorage(svg), ...options });
+  const { data, format } = await ipx("test.svg").process();
+  expect(format).toBe("svg+xml");
+  return data.toString();
+}
+
+const svgAttrs = `width="16" height="16" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"`;
+
+const xssVectors = [
+  {
+    name: "script element",
+    svg: `<svg ${svgAttrs}><script>alert(1)</script><rect width="1" height="1"/></svg>`,
+    absent: ["<script", "alert(1)"],
+  },
+  {
+    name: "namespaced script element",
+    svg: `<svg ${svgAttrs} xmlns:s="http://www.w3.org/2000/svg"><s:script>alert(1)</s:script></svg>`,
+    absent: ["script", "alert(1)"],
+  },
+  {
+    name: "event handler attributes",
+    svg: `<svg ${svgAttrs}><rect onclick="alert(1)" onmadeupevent="alert(2)" width="1" height="1"/></svg>`,
+    absent: ["onclick", "onmadeupevent", "alert("],
+  },
+  {
+    name: "foreignObject with iframe",
+    svg: `<svg ${svgAttrs}><foreignObject width="1" height="1"><iframe src="javascript:alert(1)"/></foreignObject></svg>`,
+    absent: ["foreignObject", "iframe", "javascript:"],
+  },
+  {
+    name: "SMIL event handler injection",
+    svg: `<svg ${svgAttrs}><rect width="1" height="1"><set attributeName="onload" to="alert(1)"/></rect></svg>`,
+    absent: ["<set", "onload", "alert(1)"],
+  },
+  {
+    name: "SMIL href injection",
+    svg: `<svg ${svgAttrs}><a><animate attributeName="xlink:href" values="javascript:alert(1)" dur="1s"/><rect width="1" height="1"/></a></svg>`,
+    absent: ["<animate", "javascript:"],
+  },
+  {
+    name: "javascript: link",
+    svg: `<svg ${svgAttrs}><a href="javascript:alert(1)"><rect width="1" height="1"/></a></svg>`,
+    absent: ["javascript:"],
+    present: ["<rect"],
+  },
+  {
+    name: "javascript: URI outside of links",
+    svg: `<svg ${svgAttrs}><image xlink:href="java&#9;script:alert(1)" width="1" height="1"/></svg>`,
+    absent: ["javascript:", "alert(1)"],
+  },
+  {
+    name: "entity encoded javascript: URI",
+    svg: `<?xml version="1.0"?><!DOCTYPE svg [<!ENTITY xss "javascript:alert(1)">]><svg ${svgAttrs}><a href="&xss;"><rect width="1" height="1"/></a></svg>`,
+    absent: ["javascript:", "ENTITY", "alert(1)"],
+  },
+  {
+    name: "nested svg data URI",
+    svg: `<svg ${svgAttrs}><image href="data:image/svg+xml;base64,PHN2Zz48c2NyaXB0PmFsZXJ0KDEpPC9zY3JpcHQ+PC9zdmc+" width="1" height="1"/></svg>`,
+    absent: ["data:image/svg+xml"],
+  },
+  {
+    name: "xml-stylesheet processing instruction",
+    svg: `<?xml-stylesheet type="text/xsl" href="http://evil.com/evil.xsl"?><svg ${svgAttrs}><rect width="1" height="1"/></svg>`,
+    absent: ["xml-stylesheet", "evil.xsl"],
+  },
+];
+
+// Sanitization must not depend on optimization being enabled
+describe.each([
+  { name: "svgo enabled", options: undefined },
+  { name: "svgo disabled", options: { svgo: false } as const },
+])("sanitize svg ($name)", ({ options }) => {
+  it.each(xssVectors)("$name", async ({ svg, absent, present }) => {
+    const output = await processSVG(svg, options);
+    for (const value of absent) {
+      expect(output).not.toContain(value);
+    }
+    for (const value of present || []) {
+      expect(output).toContain(value);
+    }
+  });
+
+  it("xss.svg fixture", async () => {
+    const ipx = createIPX({
+      storage: ipxFSStorage({ dir: resolve(__dirname, "assets") }),
+      ...options,
+    });
+    const { data } = await ipx("xss.svg").process();
+    const output = data.toString();
+    expect(output).not.toContain("<script");
+    expect(output).not.toContain("onclick");
+    expect(output).not.toContain("javascript:");
+    expect(output).toContain("<path");
+  });
+
+  it("keeps safe content", async () => {
+    const output = await processSVG(
+      `<svg ${svgAttrs}>` +
+        `<style>.a { fill: red }</style>` +
+        `<use href="#shape"/>` +
+        `<image href="https://example.com/image.png" width="1" height="1"/>` +
+        `<image href="data:image/png;base64,iVBORw0KGgo=" width="1" height="1"/>` +
+        `<rect id="shape" class="a" width="1" height="1">` +
+        `<animate attributeName="fill" values="#f00;#00f" dur="1s"/>` +
+        `</rect>` +
+        `</svg>`,
+      options,
+    );
+    expect(output).toContain(`<style>`);
+    expect(output).toContain(`<use href="#shape"/>`);
+    // External references are kept by design, see readme
+    expect(output).toContain(`https://example.com/image.png`);
+    expect(output).toContain(`data:image/png;base64,iVBORw0KGgo=`);
+    expect(output).toContain(`<animate attributeName="fill"`);
+  });
+});

--- a/test/svg.test.ts
+++ b/test/svg.test.ts
@@ -61,9 +61,10 @@ const xssVectors = [
   },
   {
     name: "javascript: link",
-    svg: `<svg ${svgAttrs}><a href="javascript:alert(1)"><rect width="1" height="1"/></a></svg>`,
+    svg: `<svg ${svgAttrs}><a href="javascript:alert(1)"><circle cx="8" cy="8" r="4"/></a></svg>`,
     absent: ["javascript:"],
-    present: ["<rect"],
+    // The link is unwrapped, its contents are kept
+    present: ["<circle"],
   },
   {
     name: "javascript: URI outside of links",
@@ -128,8 +129,9 @@ describe.each([
         `</svg>`,
       options,
     );
-    expect(output).toContain(`<style>`);
-    expect(output).toContain(`<use href="#shape"/>`);
+    // Styles may be inlined by the optimizer, but must not be dropped
+    expect(output).toMatch(/fill:\s?red/);
+    expect(output).toContain(`<use href="#`);
     // External references are kept by design, see readme
     expect(output).toContain(`https://example.com/image.png`);
     expect(output).toContain(`data:image/png;base64,iVBORw0KGgo=`);
@@ -137,8 +139,46 @@ describe.each([
   });
 });
 
+describe("optimize svg", () => {
+  // `removeComments` is part of `preset-default`, `removeTitle` is not
+  const svg = `<svg ${svgAttrs}><!--comment--><title>title</title><script>alert(1)</script><rect width="1" height="1"/></svg>`;
+
+  it("applies preset-default by default", async () => {
+    const output = await processSVG(svg);
+    expect(output).not.toContain("<!--comment-->");
+    expect(output).toContain("<title>title</title>");
+  });
+
+  it("uses custom plugins instead of the preset", async () => {
+    const output = await processSVG(svg, {
+      svg: { optimize: { plugins: ["removeTitle"] } },
+    });
+    expect(output).not.toContain("<title>");
+    expect(output).toContain("<!--comment-->");
+    // Sanitization is applied before the configured plugins
+    expect(output).not.toContain("<script");
+  });
+
+  it("skips optimization when disabled", async () => {
+    const output = await processSVG(svg, { svg: { optimize: false } });
+    expect(output).toContain("<!--comment-->");
+    expect(output).toContain("<title>title</title>");
+    expect(output).not.toContain("<script");
+  });
+});
+
 it("svg.unsafeSkipSanitize opts out of sanitization", async () => {
   const svg = `<svg ${svgAttrs}><script>alert(1)</script></svg>`;
-  const output = await processSVG(svg, { svg: { unsafeSkipSanitize: true } });
-  expect(output).toBe(svg);
+
+  // Optimization still runs
+  expect(
+    await processSVG(svg, { svg: { unsafeSkipSanitize: true } }),
+  ).toContain("<script>alert(1)</script>");
+
+  // With optimization disabled too, the source is served as-is
+  expect(
+    await processSVG(svg, {
+      svg: { optimize: false, unsafeSkipSanitize: true },
+    }),
+  ).toBe(svg);
 });

--- a/test/svg.test.ts
+++ b/test/svg.test.ts
@@ -55,6 +55,17 @@ const xssVectors = [
     absent: ["<set", "onload", "alert(1)"],
   },
   {
+    name: "SMIL event handler injection with padded attributeName",
+    svg: `<svg ${svgAttrs}><rect width="1" height="1"><set attributeName=" onload" to="alert(1)"/></rect></svg>`,
+    absent: ["<set", "onload", "alert(1)"],
+  },
+  {
+    // An HTML parser lowercases these into a live `<set attributeName="href">`
+    name: "SMIL injection with uppercase names",
+    svg: `<svg ${svgAttrs}><a><SET ATTRIBUTENAME="HREF" TO="javascript:alert(1)"/><circle cx="8" cy="8" r="4"/></a></svg>`,
+    absent: ["SET", "javascript:", "alert(1)"],
+  },
+  {
     name: "SMIL href injection",
     svg: `<svg ${svgAttrs}><a><animate attributeName="xlink:href" values="javascript:alert(1)" dur="1s"/><rect width="1" height="1"/></a></svg>`,
     absent: ["<animate", "javascript:"],
@@ -85,6 +96,13 @@ const xssVectors = [
     name: "xml-stylesheet processing instruction",
     svg: `<?xml-stylesheet type="text/xsl" href="http://evil.com/evil.xsl"?><svg ${svgAttrs}><rect width="1" height="1"/></svg>`,
     absent: ["xml-stylesheet", "evil.xsl"],
+  },
+  {
+    // Instructions are serialized unescaped, an HTML parser ends the bogus
+    // comment at the first `>` and treats the rest as markup
+    name: "markup smuggled in a processing instruction",
+    svg: `<?foo ><script>alert(1)</script>?><svg ${svgAttrs}><rect width="1" height="1"/></svg>`,
+    absent: ["<?foo", "<script", "alert(1)"],
   },
 ];
 
@@ -159,11 +177,30 @@ describe("optimize svg", () => {
     expect(output).not.toContain("<script");
   });
 
+  it("uses no plugins when configured with an empty list", async () => {
+    const output = await processSVG(svg, {
+      svg: { optimize: { plugins: [] } },
+    });
+    expect(output).toContain("<!--comment-->");
+    expect(output).toContain("<title>title</title>");
+    expect(output).not.toContain("<script");
+  });
+
   it("skips optimization when disabled", async () => {
     const output = await processSVG(svg, { svg: { optimize: false } });
     expect(output).toContain("<!--comment-->");
     expect(output).toContain("<title>title</title>");
     expect(output).not.toContain("<script");
+  });
+
+  it("throws a 400 for unparsable svg", async () => {
+    // Unescaped `&` is invalid XML but common in the wild
+    const svg = `<svg ${svgAttrs}><image href="https://example.com/i?a=1&b=2" width="1" height="1"/></svg>`;
+    const ipx = createIPX({ storage: inlineStorage(svg) });
+    await expect(ipx("test.svg").process()).rejects.toMatchObject({
+      statusCode: 400,
+      statusText: "IPX_INVALID_SVG",
+    });
   });
 });
 


### PR DESCRIPTION
Resolves #318.

### Sanitization no longer depends on optimization

`svgo: false` returned the source SVG untouched, silently disabling XSS protection along with optimization. Sanitization now always runs.

### Breaking: `svgo` -> `svg.optimize`

Since the option no longer controls sanitization, it moved under an `svg` key:

```diff
 createIPX({
   storage,
-  svgo: false,
+  svg: { optimize: false },
 })
```

Sanitization can still be opted out of, but only explicitly and by name: `svg: { unsafeSkipSanitize: true }`. Combined with `optimize: false` it restores the old `svgo: false` behavior of serving the source bytes untouched.

### Wider coverage

`removeScripts` only handles `<script>`, its own list of `on*` attributes and `javascript:` links on `<a>`. A new SVGO plugin (`src/svg.ts`) additionally removes:

- **SMIL attribute injection** — `<animate>`, `<animateMotion>`, `<animateTransform>` and `<set>` that target an `on*` attribute or assign an unsafe URI via `from`/`to`/`by`/`values`, which could otherwise re-introduce a handler after sanitization
- **Foreign content** — `<foreignObject>`, `<iframe>`, `<embed>`, `<object>`, `<base>`, `<link>`, `<meta>`, plus SVG Tiny's `<handler>` and `<listener>`
- **Any `on*` attribute**, on any element
- **Unsafe URIs anywhere**, not just on `<a>`: `href`/`xlink:href`/`src` are scheme-allowlisted (`http:`, `https:`, `mailto:`, `tel:`, `ftp:`, non-SVG `data:image/*`). Control characters and whitespace are stripped before the scheme check, and entity-obfuscated payloads are caught because the internal DTD is expanded during parsing
- **The internal DTD subset** and `<?xml-stylesheet?>` processing instructions

Elements and attributes are matched on their local name, so namespaced variants such as `<svg:script>` are covered.

### External references

Kept by design — stripping `<image href>`, `<use href>`, external fonts or `@import` would break legitimate images. They are not a script execution vector, but they do let an SVG make third-party requests when rendered as a document. This is now documented in a "SVG Security" section in the readme, along with the full list of what is removed and the `content-security-policy: default-src 'none'` header the bundled server sends.

### Tests

`test/svg.test.ts` covers 11 attack vectors plus the `xss.svg` fixture and a "keeps safe content" case, each run with optimization enabled **and** disabled. Every new vector was verified to leak through `optimize(svg, { plugins: ["removeScripts"] })` before this change.

### Note

With sanitization on, SVG output is always reparsed and re-serialized. Legitimate SVGs are effectively unchanged (`test/assets/nuxt.svg`: 947 -> 909 bytes, whitespace only), but the output is not byte-identical to the source anymore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened SVG sanitization to remove scripts, event handlers, unsafe SMIL patterns, and dangerous URI schemes while preserving safe references (including allowed `href`/`src` schemes and permitted `data:image/...` content).
  * Sanitization remains enabled by default and is independent of SVG optimization.
  * Added `svg.optimize` (disable SVGO) and `svg.unsafeSkipSanitize` (fully bypass sanitization for trusted SVGs).
  * Invalid SVGs now reliably fail with a 400 `IPX_INVALID_SVG` error.
* **Documentation**
  * Updated “SVG Security” section and clarified the v3→v4 SVG option migration and CSP expectations.
* **Tests**
  * Added an SVG security test suite covering default vs optimization-disabled behavior and `unsafeSkipSanitize` bypass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->