### PR TITLE
feat(server): add `parseURL` option to customize URL parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Resize to `200x200px` using `embed` method and change format to `webp`:
 
 ## Custom URL Style
 
-The `parseURL` option accepts a function that extracts the resource id and modifiers from the request URL, allowing any URL style you like.
+The `parseURL` option accepts a function that extracts the resource id and modifiers from the request URL, allowing any URL style you like. It receives the raw (still percent-encoded) request URL, so it is free to decode it however the URL style requires.
 
 **Example:** modifiers in the filename (`/<id>@@<modifiers>.<format>`), which can be preferable when prerendering images for static hosting.
 
@@ -157,7 +157,7 @@ import { createIPXFetchHandler, parseIPXURL } from "ipx";
 
 const handler = createIPXFetchHandler(ipx, {
   parseURL(url) {
-    const path = decodeURIComponent(url.pathname.slice(1));
+    const path = decodeURIComponent(new URL(url).pathname.slice(1));
 
     const match = path.match(/^(.+)@@(.+)\.([^.]+)$/);
     if (!match) {

--- a/README.md
+++ b/README.md
@@ -146,6 +146,39 @@ Resize to `200x200px` using `embed` method and change format to `webp`:
 
 `/embed,f_webp,s_200x200/static/buffalo.png`
 
+## Custom URL Style
+
+The `parseURL` option accepts a function that extracts the resource id and modifiers from the request URL, allowing any URL style you like.
+
+**Example:** modifiers in the filename (`/<id>@@<modifiers>.<format>`), which can be preferable when prerendering images for static hosting.
+
+```ts
+import { createIPXFetchHandler, parseIPXURL } from "ipx";
+
+const handler = createIPXFetchHandler(ipx, {
+  parseURL(url) {
+    const path = decodeURIComponent(url.pathname.slice(1));
+
+    const match = path.match(/^(.+)@@(.+)\.([^.]+)$/);
+    if (!match) {
+      // Not our style, fall back to the default `/<modifiers>/<id>`
+      return parseIPXURL(url);
+    }
+
+    const [, id = "", modifiersString = "", format = ""] = match;
+    const modifiers = Object.fromEntries(
+      modifiersString.split(",").map((m) => m.split("_")),
+    );
+
+    return { id, modifiers: { ...modifiers, format } };
+  },
+});
+
+// http://localhost:3000/static/buffalo.png@@s_200x200.webp
+```
+
+Returned values are escaped and validated by IPX, so custom parsers don't need to do it themselves.
+
 ## Config
 
 You can universally customize IPX configuration using `IPX_*` environment variables.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,10 @@ const handler = createIPXFetchHandler(ipx, {
 
     const [, id = "", modifiersString = "", format = ""] = match;
     const modifiers = Object.fromEntries(
-      modifiersString.split(",").map((m) => m.split("_")),
+      modifiersString.split(",").map((m) => {
+        const [key = "", ...values] = m.split("_");
+        return [key, values.join("_")];
+      }),
     );
 
     return { id, modifiers: { ...modifiers, format } };
@@ -175,9 +178,12 @@ const handler = createIPXFetchHandler(ipx, {
 });
 
 // http://localhost:3000/static/buffalo.png@@s_200x200.webp
+// http://localhost:3000/static/buffalo.png@@grayscale,w_200.webp
 ```
 
-Returned values are escaped and validated by IPX, so custom parsers don't need to do it themselves.
+The parser may be async, and can throw an `HTTPError` (re-exported from `ipx`) to reject a request with a specific status code.
+
+Returned values are escaped by IPX, so custom parsers don't need to do it themselves. Note this is not an access check — exactly as with the default URL style, what the resulting id is allowed to resolve to is enforced by the storage layer (`ipxFSStorage`'s directory boundary, `ipxHttpStorage`'s domain allowlist).
 
 ## Config
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,11 @@ export {
 } from "./ipx.ts";
 
 export {
+  type IPXHandlerOptions,
+  type IPXParsedURL,
+  type IPXURLParser,
   serveIPX,
+  parseIPXURL,
   createIPXFetchHandler,
   createIPXNodeHandler,
 } from "./server.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,9 @@ export {
   createIPX,
 } from "./ipx.ts";
 
+// Re-exported so custom `parseURL` implementations can reject requests with a status code.
+export { HTTPError } from "h3";
+
 export {
   type IPXHandlerOptions,
   type IPXParsedURL,

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,11 +15,14 @@ export type FetchHandler = (
 export interface IPXHandlerOptions {
   /**
    * Custom URL parser to extract the resource id and modifiers from the request URL.
+   * Can be async.
    *
    * Defaults to {@link parseIPXURL} which handles URLs in the form `/<modifiers>/<id>`.
    *
-   * The returned `id` and `modifiers` are always escaped by the handler, so custom
-   * parsers do not need to (and should not) escape them.
+   * Returned values are escaped (control characters) by the handler, so custom parsers
+   * do not need to escape them. This is not an access check: exactly as with the default
+   * parser, what the resulting `id` is allowed to resolve to is enforced by the storage
+   * layer. Throw an `HTTPError` to reject a request with a specific status code.
    *
    * @optional
    */
@@ -63,11 +66,14 @@ export interface IPXParsedURL {
 
   /**
    * Modifiers to apply, keyed by modifier name. See {@link IPXModifiers}.
+   *
+   * Values are coerced to strings. Use `""` (or `undefined`) for valueless
+   * modifiers such as `grayscale`.
    */
-  modifiers: Record<string, string>;
+  modifiers: Record<string, string | number | boolean | undefined>;
 }
 
-export type IPXURLParser = (url: URL) => IPXParsedURL;
+export type IPXURLParser = (url: URL) => IPXParsedURL | Promise<IPXParsedURL>;
 
 const MODIFIER_SEP = /[&,]/g;
 const MODIFIER_VAL_SEP = /[:=_]/;
@@ -81,7 +87,7 @@ const MODIFIER_VAL_SEP = /[:=_]/;
  * @returns {IPXParsedURL} The parsed resource id and modifiers. See {@link IPXParsedURL}.
  * @throws {HTTPError} If the modifiers segment is missing.
  */
-export const parseIPXURL: IPXURLParser = (url) => {
+export function parseIPXURL(url: URL): IPXParsedURL {
   const [modifiersString = "", ...idSegments] = url.pathname
     .slice(1 /* leading slash */)
     .split("/");
@@ -92,7 +98,7 @@ export const parseIPXURL: IPXURLParser = (url) => {
     throw new HTTPError({
       statusCode: 400,
       statusText: "IPX_MISSING_MODIFIERS",
-      message: `Modifiers are missing: ${id}`,
+      message: `Modifiers are missing: ${safeString(id)}`,
     });
   }
 
@@ -106,7 +112,7 @@ export const parseIPXURL: IPXURLParser = (url) => {
   }
 
   return { id, modifiers };
-};
+}
 
 // --- Handler ---
 
@@ -117,10 +123,10 @@ function createIPXHandler(
   const parseURL = opts.parseURL || parseIPXURL;
 
   return defineEventHandler(async (event: H3Event) => {
-    // Parse URL
-    const parsed = parseURL(event.url);
+    // Parse URL (never trust the parser output: it can be user provided)
+    const parsed: Partial<IPXParsedURL> = (await parseURL(event.url)) || {};
 
-    // Sanitize and validate id
+    // Escape and validate id
     const id = safeString(parsed.id);
     if (!id || id === "/") {
       throw new HTTPError({
@@ -130,9 +136,9 @@ function createIPXHandler(
       });
     }
 
-    // Sanitize modifiers (never trust the parser output)
+    // Escape modifiers
     const modifiers: Record<string, string> = Object.create(null);
-    for (const [key, value] of Object.entries(parsed.modifiers)) {
+    for (const [key, value] of Object.entries(parsed.modifiers || {})) {
       modifiers[safeString(key)] = safeString(value);
     }
 
@@ -241,8 +247,8 @@ function autoDetectFormat(acceptHeader: string, animated: boolean): string {
   return acceptMime?.split("/")[1] || "jpeg";
 }
 
-function safeString(input: string | undefined) {
-  return JSON.stringify(input)
+function safeString(input: unknown) {
+  return JSON.stringify(input ?? "")
     .replace(/^"|"$/g, "")
     .replace(/\\+/g, "\\")
     .replace(/\\"/g, '"');

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import getEtag from "etag";
 import { negotiate } from "@fastify/accept-negotiator";
-import { decode, parseURL as parseURLParts } from "ufo";
+import { decode } from "ufo";
 import { defineEventHandler, HTTPError } from "h3";
 import { requireModule } from "./utils.ts";
 
@@ -17,8 +17,8 @@ export interface IPXHandlerOptions {
    * Custom URL parser to extract the resource id and modifiers from the request URL.
    * Can be async.
    *
-   * Receives the raw (still percent-encoded) request URL, so parsers can decode it
-   * themselves without going through h3's normalization.
+   * Receives the raw (absolute, still percent-encoded) request URL, so parsers can
+   * decode it themselves without going through h3's normalization.
    *
    * Defaults to {@link parseIPXURL} which handles URLs in the form `/<modifiers>/<id>`.
    *
@@ -88,13 +88,13 @@ const MODIFIER_VAL_SEP = /[:=_]/;
  *
  * Use `_` as the modifiers segment to apply none (`/_/image.png`).
  *
- * @param {string} url - The raw request URL.
+ * @param {string} url - The raw (absolute) request URL.
  * @returns {IPXParsedURL} The parsed resource id and modifiers. See {@link IPXParsedURL}.
  * @throws {HTTPError} If the modifiers segment is missing.
  */
 export function parseIPXURL(url: string): IPXParsedURL {
-  const [modifiersString = "", ...idSegments] = parseURLParts(url)
-    .pathname.slice(1 /* leading slash */)
+  const [modifiersString = "", ...idSegments] = new URL(url).pathname
+    .slice(1 /* leading slash */)
     .split("/");
 
   const id = decode(idSegments.join("/"));

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,5 @@
 import getEtag from "etag";
 import { negotiate } from "@fastify/accept-negotiator";
-import { decode } from "ufo";
 import { defineEventHandler, HTTPError } from "h3";
 import { requireModule } from "./utils.ts";
 
@@ -252,6 +251,15 @@ function autoDetectFormat(acceptHeader: string, animated: boolean): string {
     "image/gif",
   ]);
   return acceptMime?.split("/")[1] || "jpeg";
+}
+
+function decode(input: string) {
+  try {
+    return decodeURIComponent(input);
+  } catch {
+    // Keep malformed percent-encoding as-is (e.g. `100%.jpg`)
+    return input;
+  }
 }
 
 function safeString(input: unknown) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,48 +12,116 @@ export type FetchHandler = (
   request: Request | string | URL,
 ) => Response | Promise<Response>;
 
-export function createIPXFetchHandler(ipx: IPX): FetchHandler {
-  return createIPXHandler(ipx).fetch as FetchHandler;
+export interface IPXHandlerOptions {
+  /**
+   * Custom URL parser to extract the resource id and modifiers from the request URL.
+   *
+   * Defaults to {@link parseIPXURL} which handles URLs in the form `/<modifiers>/<id>`.
+   *
+   * The returned `id` and `modifiers` are always escaped by the handler, so custom
+   * parsers do not need to (and should not) escape them.
+   *
+   * @optional
+   */
+  parseURL?: IPXURLParser;
 }
 
-export function createIPXNodeHandler(ipx: IPX): NodeHttpHandler {
+export function createIPXFetchHandler(
+  ipx: IPX,
+  opts?: IPXHandlerOptions,
+): FetchHandler {
+  return createIPXHandler(ipx, opts).fetch as FetchHandler;
+}
+
+export function createIPXNodeHandler(
+  ipx: IPX,
+  opts?: IPXHandlerOptions,
+): NodeHttpHandler {
   const { toNodeHandler } =
     requireModule<typeof import("srvx/node")>("srvx/node");
-  const fetch = createIPXFetchHandler(ipx);
+  const fetch = createIPXFetchHandler(ipx, opts);
   return toNodeHandler(fetch);
 }
 
 export function serveIPX(
   ipx: IPX,
-  opts?: Omit<ServerOptions, "fetch">,
+  opts?: Omit<ServerOptions, "fetch"> & IPXHandlerOptions,
 ): Server {
   const { serve } = requireModule<typeof import("srvx")>("srvx");
-  const fetch = createIPXFetchHandler(ipx);
-  return serve({ ...opts, fetch });
+  const { parseURL, ...serverOptions } = opts || {};
+  const fetch = createIPXFetchHandler(ipx, { parseURL });
+  return serve({ ...serverOptions, fetch });
 }
 
-// --- Handler ---
+// --- URL Parser ---
+
+export interface IPXParsedURL {
+  /**
+   * The identifier of the source image (path or URL, depending on the storage).
+   */
+  id: string;
+
+  /**
+   * Modifiers to apply, keyed by modifier name. See {@link IPXModifiers}.
+   */
+  modifiers: Record<string, string>;
+}
+
+export type IPXURLParser = (url: URL) => IPXParsedURL;
 
 const MODIFIER_SEP = /[&,]/g;
 const MODIFIER_VAL_SEP = /[:=_]/;
 
-function createIPXHandler(ipx: IPX): EventHandlerWithFetch {
+/**
+ * Default IPX URL parser, handling URLs in the form `/<modifiers>/<id>`.
+ *
+ * Use `_` as the modifiers segment to apply none (`/_/image.png`).
+ *
+ * @param {URL} url - The request URL. See {@link URL}.
+ * @returns {IPXParsedURL} The parsed resource id and modifiers. See {@link IPXParsedURL}.
+ * @throws {HTTPError} If the modifiers segment is missing.
+ */
+export const parseIPXURL: IPXURLParser = (url) => {
+  const [modifiersString = "", ...idSegments] = url.pathname
+    .slice(1 /* leading slash */)
+    .split("/");
+
+  const id = decode(idSegments.join("/"));
+
+  if (!modifiersString) {
+    throw new HTTPError({
+      statusCode: 400,
+      statusText: "IPX_MISSING_MODIFIERS",
+      message: `Modifiers are missing: ${id}`,
+    });
+  }
+
+  const modifiers: Record<string, string> = Object.create(null);
+
+  if (modifiersString !== "_") {
+    for (const p of modifiersString.split(MODIFIER_SEP)) {
+      const [key = "", ...values] = p.split(MODIFIER_VAL_SEP);
+      modifiers[key] = values.map((v) => decode(v)).join("_");
+    }
+  }
+
+  return { id, modifiers };
+};
+
+// --- Handler ---
+
+function createIPXHandler(
+  ipx: IPX,
+  opts: IPXHandlerOptions = {},
+): EventHandlerWithFetch {
+  const parseURL = opts.parseURL || parseIPXURL;
+
   return defineEventHandler(async (event: H3Event) => {
     // Parse URL
-    const [modifiersString = "", ...idSegments] = event.url.pathname
-      .slice(1 /* leading slash */)
-      .split("/");
+    const parsed = parseURL(event.url);
 
-    const id = safeString(decode(idSegments.join("/")));
-
-    // Validate
-    if (!modifiersString) {
-      throw new HTTPError({
-        statusCode: 400,
-        statusText: "IPX_MISSING_MODIFIERS",
-        message: `Modifiers are missing: ${id}`,
-      });
-    }
+    // Sanitize and validate id
+    const id = safeString(parsed.id);
     if (!id || id === "/") {
       throw new HTTPError({
         statusCode: 400,
@@ -62,17 +130,10 @@ function createIPXHandler(ipx: IPX): EventHandlerWithFetch {
       });
     }
 
-    // Construct modifiers
+    // Sanitize modifiers (never trust the parser output)
     const modifiers: Record<string, string> = Object.create(null);
-
-    // Read modifiers from first segment
-    if (modifiersString !== "_") {
-      for (const p of modifiersString.split(MODIFIER_SEP)) {
-        const [key, ...values] = p.split(MODIFIER_VAL_SEP);
-        modifiers[safeString(key)] = values
-          .map((v) => safeString(decode(v)))
-          .join("_");
-      }
+    for (const [key, value] of Object.entries(parsed.modifiers)) {
+      modifiers[safeString(key)] = safeString(value);
     }
 
     // Auto format

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import getEtag from "etag";
 import { negotiate } from "@fastify/accept-negotiator";
-import { decode } from "ufo";
+import { decode, parseURL as parseURLParts } from "ufo";
 import { defineEventHandler, HTTPError } from "h3";
 import { requireModule } from "./utils.ts";
 
@@ -16,6 +16,9 @@ export interface IPXHandlerOptions {
   /**
    * Custom URL parser to extract the resource id and modifiers from the request URL.
    * Can be async.
+   *
+   * Receives the raw (still percent-encoded) request URL, so parsers can decode it
+   * themselves without going through h3's normalization.
    *
    * Defaults to {@link parseIPXURL} which handles URLs in the form `/<modifiers>/<id>`.
    *
@@ -73,7 +76,9 @@ export interface IPXParsedURL {
   modifiers: Record<string, string | number | boolean | undefined>;
 }
 
-export type IPXURLParser = (url: URL) => IPXParsedURL | Promise<IPXParsedURL>;
+export type IPXURLParser = (
+  url: string,
+) => IPXParsedURL | Promise<IPXParsedURL>;
 
 const MODIFIER_SEP = /[&,]/g;
 const MODIFIER_VAL_SEP = /[:=_]/;
@@ -83,13 +88,13 @@ const MODIFIER_VAL_SEP = /[:=_]/;
  *
  * Use `_` as the modifiers segment to apply none (`/_/image.png`).
  *
- * @param {URL} url - The request URL. See {@link URL}.
+ * @param {string} url - The raw request URL.
  * @returns {IPXParsedURL} The parsed resource id and modifiers. See {@link IPXParsedURL}.
  * @throws {HTTPError} If the modifiers segment is missing.
  */
-export function parseIPXURL(url: URL): IPXParsedURL {
-  const [modifiersString = "", ...idSegments] = url.pathname
-    .slice(1 /* leading slash */)
+export function parseIPXURL(url: string): IPXParsedURL {
+  const [modifiersString = "", ...idSegments] = parseURLParts(url)
+    .pathname.slice(1 /* leading slash */)
     .split("/");
 
   const id = decode(idSegments.join("/"));
@@ -124,7 +129,9 @@ function createIPXHandler(
 
   return defineEventHandler(async (event: H3Event) => {
     // Parse URL (never trust the parser output: it can be user provided)
-    const parsed: Partial<IPXParsedURL> = (await parseURL(event.url)) || {};
+    // `event.req.url` is used over `event.url` since the latter is normalized by
+    // h3, silently dropping percent-encoded tab/newline/carriage-return.
+    const parsed: Partial<IPXParsedURL> = (await parseURL(event.req.url)) || {};
 
     // Escape and validate id
     const id = safeString(parsed.id);

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -39,7 +39,7 @@ describe("server", () => {
   describe("parseIPXURL", () => {
     it("parses modifiers and id", () => {
       expect(
-        parseIPXURL(new URL("http://example.com/s_200x200,f_webp/test.jpg")),
+        parseIPXURL("http://example.com/s_200x200,f_webp/test.jpg"),
       ).toMatchObject({
         id: "test.jpg",
         modifiers: { s: "200x200", f: "webp" },
@@ -47,23 +47,42 @@ describe("server", () => {
     });
 
     it("supports `_` for no modifiers", () => {
-      const parsed = parseIPXURL(
-        new URL("http://example.com/_/nested/test.jpg"),
-      );
+      const parsed = parseIPXURL("http://example.com/_/nested/test.jpg");
       expect(parsed.id).toEqual("nested/test.jpg");
       expect({ ...parsed.modifiers }).toEqual({});
     });
 
     it("supports valueless modifiers", () => {
-      const parsed = parseIPXURL(new URL("http://example.com/grayscale/a.jpg"));
+      const parsed = parseIPXURL("http://example.com/grayscale/a.jpg");
       expect({ ...parsed.modifiers }).toEqual({ grayscale: "" });
     });
+
+    it("ignores the query string", () => {
+      const parsed = parseIPXURL("http://example.com/w_200/a.jpg?v=1#x");
+      expect(parsed.id).toEqual("a.jpg");
+      expect({ ...parsed.modifiers }).toEqual({ w: "200" });
+    });
+  });
+
+  // h3 normalizes `event.url`, which drops percent-encoded tab/newline/CR
+  it("parses the raw request URL", async () => {
+    const handler = createIPXFetchHandler(ipx);
+    const cases = [
+      ["%09", String.raw`a\tb.jpg`],
+      ["%0A", String.raw`a\nb.jpg`],
+      ["%0D", String.raw`a\rb.jpg`],
+      ["%2F", "a/b.jpg"],
+    ];
+    for (const [encoded, expected] of cases) {
+      await handler(`http://example.com/w_200/a${encoded}b.jpg`);
+      expect(lastRequest.id).toEqual(expected);
+    }
   });
 
   describe("parseURL option", () => {
     // `/<id>@@<modifiers>.<format>`
     const parseURL: IPXURLParser = (url) => {
-      const path = decodeURIComponent(url.pathname.slice(1));
+      const path = decodeURIComponent(new URL(url).pathname.slice(1));
       const match = path.match(/^(.+)@@(.+)\.([^.]+)$/);
       if (!match) {
         return { id: path, modifiers: {} };
@@ -134,7 +153,7 @@ describe("server", () => {
     it("can delegate to the default parser", async () => {
       const handler = createIPXFetchHandler(ipx, {
         parseURL: (url) =>
-          url.pathname.includes("@@") ? parseURL(url) : parseIPXURL(url),
+          url.includes("@@") ? parseURL(url) : parseIPXURL(url),
       });
       await handler("http://example.com/w_200/test.jpg");
       expect(lastRequest).toMatchObject({

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   type IPX,
   type IPXURLParser,
@@ -7,7 +7,11 @@ import {
 } from "../src/index.ts";
 
 describe("server", () => {
-  let lastRequest: { id: string; modifiers?: Record<string, any> };
+  let lastRequest: { id?: string; modifiers?: Record<string, any> };
+
+  beforeEach(() => {
+    lastRequest = {};
+  });
 
   const ipx: IPX = (id, modifiers?, _requestOptions?) => {
     lastRequest = { id, modifiers };
@@ -43,9 +47,16 @@ describe("server", () => {
     });
 
     it("supports `_` for no modifiers", () => {
-      expect(
-        parseIPXURL(new URL("http://example.com/_/nested/test.jpg")),
-      ).toMatchObject({ id: "nested/test.jpg", modifiers: {} });
+      const parsed = parseIPXURL(
+        new URL("http://example.com/_/nested/test.jpg"),
+      );
+      expect(parsed.id).toEqual("nested/test.jpg");
+      expect({ ...parsed.modifiers }).toEqual({});
+    });
+
+    it("supports valueless modifiers", () => {
+      const parsed = parseIPXURL(new URL("http://example.com/grayscale/a.jpg"));
+      expect({ ...parsed.modifiers }).toEqual({ grayscale: "" });
     });
   });
 
@@ -59,7 +70,10 @@ describe("server", () => {
       }
       const [, id = "", modifiersString = "", format = ""] = match;
       const modifiers = Object.fromEntries(
-        modifiersString.split(",").map((m) => m.split("_")),
+        modifiersString.split(",").map((m) => {
+          const [key = "", ...values] = m.split("_");
+          return [key, values.join("_")];
+        }),
       );
       return { id, modifiers: { ...modifiers, format } };
     };
@@ -78,7 +92,43 @@ describe("server", () => {
       const handler = createIPXFetchHandler(ipx, { parseURL });
       const res = await handler("http://example.com/test.png");
       await expect(res.text()).resolves.toEqual("data");
-      expect(lastRequest).toMatchObject({ id: "test.png", modifiers: {} });
+      expect(lastRequest.id).toEqual("test.png");
+      expect({ ...lastRequest.modifiers }).toEqual({});
+    });
+
+    it("supports valueless modifiers", async () => {
+      const handler = createIPXFetchHandler(ipx, { parseURL });
+      const res = await handler("http://example.com/test.png@@grayscale.webp");
+      expect(res.status).toEqual(200);
+      expect({ ...lastRequest.modifiers }).toEqual({
+        grayscale: "",
+        format: "webp",
+      });
+    });
+
+    it("supports async parsers", async () => {
+      const handler = createIPXFetchHandler(ipx, {
+        parseURL: async (url) => parseIPXURL(url),
+      });
+      const res = await handler("http://example.com/w_200/test.jpg");
+      expect(res.status).toEqual(200);
+      expect(lastRequest).toMatchObject({
+        id: "test.jpg",
+        modifiers: { w: "200" },
+      });
+    });
+
+    it("does not crash on malformed parser output", async () => {
+      for (const parseURL of [
+        () => undefined,
+        () => ({ id: "test.jpg" }),
+        () => ({ id: "test.jpg", modifiers: { w: 200, grayscale: undefined } }),
+      ] as unknown as IPXURLParser[]) {
+        const handler = createIPXFetchHandler(ipx, { parseURL });
+        const res = await handler("http://example.com/test.jpg");
+        expect([200, 400]).toContain(res.status);
+      }
+      expect({ ...lastRequest.modifiers }).toEqual({ w: "200", grayscale: "" });
     });
 
     it("can delegate to the default parser", async () => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { type IPX, createIPXFetchHandler } from "../src/index.ts";
+import {
+  type IPX,
+  type IPXURLParser,
+  createIPXFetchHandler,
+  parseIPXURL,
+} from "../src/index.ts";
 
 describe("server", () => {
-  const ipx: IPX = (_id, _modifiers?, _requestOptions?) => {
+  let lastRequest: { id: string; modifiers?: Record<string, any> };
+
+  const ipx: IPX = (id, modifiers?, _requestOptions?) => {
+    lastRequest = { id, modifiers };
     return {
       getSourceMeta: async () => {
         return { maxAge: 3600, mtime: new Date() };
@@ -22,6 +30,98 @@ describe("server", () => {
     const handler = createIPXFetchHandler(ipx);
     const res = await handler("http://example.com/w_200/test.jpg");
     await expect(res.text()).resolves.toEqual("data");
+  });
+
+  describe("parseIPXURL", () => {
+    it("parses modifiers and id", () => {
+      expect(
+        parseIPXURL(new URL("http://example.com/s_200x200,f_webp/test.jpg")),
+      ).toMatchObject({
+        id: "test.jpg",
+        modifiers: { s: "200x200", f: "webp" },
+      });
+    });
+
+    it("supports `_` for no modifiers", () => {
+      expect(
+        parseIPXURL(new URL("http://example.com/_/nested/test.jpg")),
+      ).toMatchObject({ id: "nested/test.jpg", modifiers: {} });
+    });
+  });
+
+  describe("parseURL option", () => {
+    // `/<id>@@<modifiers>.<format>`
+    const parseURL: IPXURLParser = (url) => {
+      const path = decodeURIComponent(url.pathname.slice(1));
+      const match = path.match(/^(.+)@@(.+)\.([^.]+)$/);
+      if (!match) {
+        return { id: path, modifiers: {} };
+      }
+      const [, id = "", modifiersString = "", format = ""] = match;
+      const modifiers = Object.fromEntries(
+        modifiersString.split(",").map((m) => m.split("_")),
+      );
+      return { id, modifiers: { ...modifiers, format } };
+    };
+
+    it("overrides the default parser", async () => {
+      const handler = createIPXFetchHandler(ipx, { parseURL });
+      const res = await handler("http://example.com/test.png@@w_300.webp");
+      await expect(res.text()).resolves.toEqual("data");
+      expect(lastRequest).toMatchObject({
+        id: "test.png",
+        modifiers: { w: "300", format: "webp" },
+      });
+    });
+
+    it("works without modifiers", async () => {
+      const handler = createIPXFetchHandler(ipx, { parseURL });
+      const res = await handler("http://example.com/test.png");
+      await expect(res.text()).resolves.toEqual("data");
+      expect(lastRequest).toMatchObject({ id: "test.png", modifiers: {} });
+    });
+
+    it("can delegate to the default parser", async () => {
+      const handler = createIPXFetchHandler(ipx, {
+        parseURL: (url) =>
+          url.pathname.includes("@@") ? parseURL(url) : parseIPXURL(url),
+      });
+      await handler("http://example.com/w_200/test.jpg");
+      expect(lastRequest).toMatchObject({
+        id: "test.jpg",
+        modifiers: { w: "200" },
+      });
+      await handler("http://example.com/test.png@@w_300.webp");
+      expect(lastRequest).toMatchObject({
+        id: "test.png",
+        modifiers: { w: "300", format: "webp" },
+      });
+    });
+
+    it("escapes parser output", async () => {
+      const handler = createIPXFetchHandler(ipx, {
+        parseURL: () => ({
+          id: "test\n.jpg",
+          modifiers: { f: "webp\r\n" },
+        }),
+      });
+      await handler("http://example.com/anything");
+      expect(lastRequest).toMatchObject({
+        id: String.raw`test\n.jpg`,
+        modifiers: { f: String.raw`webp\r\n` },
+      });
+    });
+
+    it("still validates a missing id", async () => {
+      const handler = createIPXFetchHandler(ipx, {
+        parseURL: () => ({ id: "", modifiers: {} }),
+      });
+      const res = await handler("http://example.com/w_200/test.jpg");
+      expect(await res.json()).toMatchObject({
+        status: 400,
+        statusText: "IPX_MISSING_ID",
+      });
+    });
   });
 
   describe("error handling", () => {


### PR DESCRIPTION
Alternative take on #259, reworked against the current `srvx`/`h3` server API.

Adds a `parseURL` option so any URL style can be used instead of the built-in `/<modifiers>/<id>`:

```ts
import { createIPXFetchHandler, parseIPXURL } from "ipx";

// /static/buffalo.png@@s_200x200.webp
const handler = createIPXFetchHandler(ipx, {
  parseURL(url) {
    const path = decodeURIComponent(new URL(url).pathname.slice(1));

    const match = path.match(/^(.+)@@(.+)\.([^.]+)$/);
    if (!match) {
      // Not our style, fall back to the default `/<modifiers>/<id>`
      return parseIPXURL(url);
    }

    const [, id = "", modifiersString = "", format = ""] = match;
    const modifiers = Object.fromEntries(
      modifiersString.split(",").map((m) => {
        const [key = "", ...values] = m.split("_");
        return [key, values.join("_")];
      }),
    );

    return { id, modifiers: { ...modifiers, format } };
  },
});
```

Available on `createIPXFetchHandler`, `createIPXNodeHandler` and `serveIPX`. When unset, behavior is unchanged.

### Differences from #259

- **The parser is `(url: string) => { id, modifiers }`, not `(event: H3Event) => ...`.** It needs nothing from the request beyond the URL, so keeping a framework type out of the public contract means it doesn't have to be re-designed on every h3/srvx iteration — which is what happened to #259. It's also unit-testable with a bare string.
- **Escaping and validation stay in the handler.** In #259 the parser returned the final `id`, which made escaping the user's problem — hence its `fix: re-apply safeString() protection to parsed resource id` commit. Here the handler applies `safeString()` to whatever comes back and copies modifiers into a null-prototype object, so a third-party parser can't reintroduce that.
- **`IPX_MISSING_MODIFIERS` moved into the default parser.** It's only meaningful for the `/<modifiers>/<id>` scheme; a custom scheme where modifiers are optional shouldn't be forced to throw it. `IPX_MISSING_ID` is universal and stays in the handler.
- **`parseIPXURL()` is exported.** Custom parsers can delegate to it, which covers "support both styles at the same time" without shipping the named presets that were rejected in #259.
- **Named `parseURL`**, per the naming preference in #259.

No SVG changes, no presets, no `~` marker — same scope decision as #259 ended up with.

### Notes

- **The parser receives the raw request URL string.** The handler reads `event.req.url` rather than `event.url`, because h3 normalizes the latter: it decodes the pathname, which silently drops percent-encoded tab/newline/carriage-return. Parsers get the still-encoded URL and decode it however their style requires, and the default parser now decodes exactly once instead of double-decoding through h3. (When the handler is mounted under a base — `app.mount("/ipx", handler)` — h3 rewrites the request to strip the prefix, which applies its own decoding first; base stripping keeps working either way.)
- **Parsers may be async**, and `HTTPError` is re-exported from `ipx` so a parser can reject a request with a specific status code.
- **Malformed parser output doesn't crash the handler**: a missing return value or missing `modifiers` falls through to the normal `IPX_MISSING_ID` / empty-modifiers path, and non-string modifier values (numbers, `undefined` for valueless modifiers) are coerced to strings.
- No fallback semantics on the return value (`undefined` meaning "use default") — explicitly calling `parseIPXURL(url)` is just as short and doesn't add precedence rules to document.

Tests cover `parseIPXURL` directly, the option override, async parsers, delegation to the default, escaping of parser output, malformed parser output, raw-URL parsing of percent-encoded control characters, and that `IPX_MISSING_ID` still applies to custom parsers.

Resolves #54, resolves #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom URL styles when processing image requests.
  * Added configurable URL parsing for extracting image identifiers and transformation modifiers.
  * Exported URL parsing utilities and related handler types for broader integration.
  * Added documentation and examples for implementing custom URL formats.

* **Bug Fixes**
  * Improved validation and escaping of parsed image identifiers and modifiers.
  * Improved handling of missing or invalid image identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
