### PR TITLE
fix(storage/http): preserve explicit zero maxAge

### DIFF
--- a/src/storage/http.ts
+++ b/src/storage/http.ts
@@ -18,6 +18,9 @@ export type HTTPStorageOptions = {
 
   /**
    * Default maximum age (in seconds) for cache control. If not specified, defaults to the environment setting or 300 seconds.
+   *
+   * `0` is meaningful and is passed through as-is — it disables caching rather than
+   * falling back to the default.
    * @optional
    */
   maxAge?: number;
@@ -264,7 +267,7 @@ export function ipxHttpStorage(_options: HTTPStorageOptions = {}): IPXStorage {
   let _domains =
     _options.domains || getEnv<string | string[]>("IPX_HTTP_DOMAINS") || [];
   const defaultMaxAge =
-    _options.maxAge || getEnv<string | number>("IPX_HTTP_MAX_AGE") || 300;
+    _options.maxAge ?? getEnv<string | number>("IPX_HTTP_MAX_AGE") ?? 300;
   const fetchOptions: RequestInit =
     _options.fetchOptions ||
     getEnv<RequestInit>("IPX_HTTP_FETCH_OPTIONS") ||

--- a/test/storage/http.test.ts
+++ b/test/storage/http.test.ts
@@ -23,6 +23,19 @@ describe("http", () => {
         "Forbidden host: localhost",
       );
     });
+
+    it("preserves an explicit zero maxAge when the response has no cache-control", async () => {
+      const fetch = vi.fn().mockResolvedValue(new Response(null));
+      vi.stubGlobal("fetch", fetch);
+      const storage = ipxHttpStorage({
+        domains: ["example.com"],
+        maxAge: 0,
+      });
+
+      await expect(
+        storage.getMeta("https://example.com/image.png"),
+      ).resolves.toMatchObject({ maxAge: 0 });
+    });
   });
 
   describe("validateId", () => {


### PR DESCRIPTION
## Problem

When an HTTP source response has no `cache-control` header, `ipxHttpStorage({ maxAge: 0 })` was coerced to the default `300` seconds by falsy-value fallback. Deployments intending to disable caching therefore received the wrong cache duration.

## Fix

Use nullish fallback for the HTTP storage default so an explicit zero is preserved. The option documentation now records that zero disables caching.

## Tests

- `pnpm vitest test/storage/http.test.ts -t 'preserves an explicit zero maxAge'` — failed before the fix with `300`, passed after the fix
- `pnpm vitest test/storage/http.test.ts --run` — passed, 90 tests
- `pnpm build` — passed
- `pnpm test` — passed, 453 tests and 9 skipped
- `git diff HEAD^ HEAD --check` — passed

## Compatibility

Only an explicit `maxAge: 0` changes. Nonzero options, environment fallback, and upstream `cache-control` handling are unchanged; no API or dependency changes are introduced.

## Related issue

Independent reproduction; no matching open issue was found. Historical cache-control issues #166 and #179 concern different, closed behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Honor an explicitly configured cache duration of `0`, disabling caching instead of applying the default duration.
  * Preserve zero-valued cache settings when responses do not include cache-control headers.

* **Documentation**
  * Clarified that setting the cache duration to `0` disables caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->